### PR TITLE
chore: add twitter and itunes app store urls

### DIFF
--- a/LocalJournals/sites.csv
+++ b/LocalJournals/sites.csv
@@ -1,738 +1,738 @@
-awsOrigin,domain,facebookUrl,siteName
-3.212.144.110,aikentimes.com,,
-3.212.144.110,albanystandard.com,,
-3.212.144.110,alleghenyhighlandstoday.com,,
-3.212.144.110,ashevillereporter.com,https://www.facebook.com/Asheville-Reporter-120029399386332/,Asheville Reporter
-3.212.144.110,athensreporter.com,,
-3.212.144.110,atlstandard.com,,
-3.212.144.110,berkeleyleader.com,,
-3.212.144.110,bluestonenews.com,,
-3.212.144.110,brevardsun.com,,Brevard Sun
-3.212.144.110,burlingtonreporter.com,https://www.facebook.com/Burlington-Reporter-121484399239483/,Burlington Reporter
-3.212.144.110,cabarrustoday.com,https://www.facebook.com/Cabarrus-Today-110013390395328/,Cabarrus Today
-3.212.144.110,centralbrowardnews.com,,Central Broward News
-3.212.144.110,centralgeorgianews.com,,
-3.212.144.110,centralnovanews.com,,
-3.212.144.110,centralshenandoahnews.com,,
-3.212.144.110,centralvatimes.com,,
-3.212.144.110,chapelhillreview.com,https://www.facebook.com/Chapel-Hill-Review-103130714424239/,Chapel Hill Review
-3.212.144.110,charlestonleader.com,,
-3.212.144.110,charlestonreporter.com,,
-3.212.144.110,claycotimes.com,,Clay County Times
-3.212.144.110,coastalganews.com,,
-3.212.144.110,cobbreporter.com,,
-3.212.144.110,columbiastandard.com,,
-3.212.144.110,dekalbganews.com,,
-3.212.144.110,dorchestertoday.com,,
-3.212.144.110,durhamreporter.com,https://www.facebook.com/Durham-Reporter-118375432886638/,Durham Reporter
-3.212.144.110,duvaltimes.com,,Duval Times
-3.212.144.110,easternshoretimes.com,,
-3.212.144.110,easthillsboroughnews.com,,East Hillsborough News
-3.212.144.110,eastlakenormannews.com,https://www.facebook.com/East-Lake-Norman-News-105190370881365/,East Lake Norman News
-3.212.144.110,eastpanhandlenews.com,,East Panhandle News
-3.212.144.110,eastpanhandletimes.com,,
-3.212.144.110,eastvolusianews.com,,East Volusia News
-3.212.144.110,eastwaketimes.com,https://www.facebook.com/East-Wake-Times-109459453784640/,East Wake Times
-3.212.144.110,ecgeorgianews.com,,
-3.212.144.110,ecnorthcarolinanews.com,https://www.facebook.com/EC-North-Carolina-News-105550317511769/,EC North Carolina News
-3.212.144.110,ecvirginianews.com,,
-3.212.144.110,emeraldcoasttimes.com,,Emerald Coast Times
-3.212.144.110,fayettevilletoday.com,https://www.facebook.com/Fayetteville-Today-112462826815757/,Fayetteville Today
-3.212.144.110,firststatetimes.com,https://www.facebook.com/First-State-Times-111265990223655/,First State Times
-3.212.144.110,foothillsreview.com,https://www.facebook.com/Foothills-Review-101128717956444/,Foothills Review
-3.212.144.110,fredericksburgleader.com,,
-3.212.144.110,gastoniatimes.com,https://www.facebook.com/Gastonia-Times-119779936078342/,Gastonia Times
-3.212.144.110,gatewayreporter.com,,
-3.212.144.110,georgiamountainnews.com,,
-3.212.144.110,greensbororeporter.com,https://www.facebook.com/Greensboro-Reporter-116196246439218/,Greensboro Reporter
-3.212.144.110,greenvilleleader.com,,
-3.212.144.110,greenvillereporter.com,https://www.facebook.com/Greenville-Reporter-121924869195889/,Greenville Reporter
-3.212.144.110,henricotimes.com,,
-3.212.144.110,hernandoreporter.com,,Hernando Reporter
-3.212.144.110,hickorysun.com,https://www.facebook.com/Hickory-Sun-111121563617189/,Hickory Sun
-3.212.144.110,highcountrytimes.com,https://www.facebook.com/High-Country-Times-107671310631667/,High Country Times
-3.212.144.110,hiltonheadreporter.com,,
-3.212.144.110,huntingtontimes.com,,
-3.212.144.110,ibxnews.com,https://www.facebook.com/IBX-News-116157859776600/,IBX News
-3.212.144.110,injouercad.us,#N/A,
-3.212.144.110,johnstonreporter.com,https://www.facebook.com/Johnston-Reporter-113415450052248,Johnston Reporter
-3.212.144.110,kentcountytoday.com,https://www.facebook.com/Kent-County-Today-114894533256835/,Kent County Today
-3.212.144.110,keywestreporter.com,,Key West Reporter
-3.212.144.110,leetoday.com,,Lee Today
-3.212.144.110,lowerwestscnews.com,,
-3.212.144.110,lynchburgreporter.com,,
-3.212.144.110,macontimes.com,,
-3.212.144.110,manateereview.com,,Manatee Review
-3.212.144.110,miamicourant.com,,Miami Courant
-3.212.144.110,mountainstatetimes.com,,
-3.212.144.110,myrtlebeachleader.com,,
-3.212.144.110,nantahalanews.com,https://www.facebook.com/Nantahala-News-111249553604479/,Nantahala News
-3.212.144.110,naplesstandard.com,,Naples Standard
-3.212.144.110,naturecoasttimes.com,,Nature Coast Times
-3.212.144.110,ncfloridanews.com,,NC Florida News
-3.212.144.110,ncgeorgianews.com,,
-3.212.144.110,ncncnews.com,https://www.facebook.com/NC-North-Carolina-News-112558680139451/,NC North Carolina News
-3.212.144.110,ncsctimes.com,,
-3.212.144.110,ncunionnews.com,https://www.facebook.com/Union-News-114326133299310/,Union News
-3.212.144.110,ncwvnews.com,,
-3.212.144.110,neatlantanews.com,,
-3.212.144.110,nefloridanews.com,,NE Florida News
-3.212.144.110,nepiedmontnews.com,https://www.facebook.com/NE-Piedmont-News-108836913847873/,NE Piedmont News
-3.212.144.110,newrivervalleytimes.com,,
-3.212.144.110,northbrowardnews.com,,North Broward News
-3.212.144.110,northcharlottetoday.com,,North Charlotte Today
-3.212.144.110,northcharolettenews.com,,
-3.212.144.110,northernnecktimes.com,,
-3.212.144.110,northfairfaxnews.com,,
-3.212.144.110,northfultontoday.com,,
-3.212.144.110,northguilfordnews.com,https://www.facebook.com/North-Guilford-News-117744056288004/,North Guilford News
-3.212.144.110,northgwinnettnews.com,,
-3.212.144.110,northiredellnews.com,https://www.facebook.com/North-Iredell-News-118400609555835/,North Iredell News
-3.212.144.110,northlaketimes.com,,North Lake Times
-3.212.144.110,northmecklenburgnews.com,https://www.facebook.com/North-Mecklenburg-News-116572919739799,North Mecklenburg News
-3.212.144.110,northmianews.com,,North Miami-Dade News
-3.212.144.110,northnewcastlenews.com,https://www.facebook.com/North-New-Castle-News-106071607478194/,North New Castle News
-3.212.144.110,northorlandonews.com,,North Orlando News
-3.212.144.110,northpalmbeachtoday.com,,North Palm Beach Today
-3.212.144.110,northpanhandlenews.com,,North Panhandle News
-3.212.144.110,northpanhandletimes.com,,
-3.212.144.110,northpinellasnews.com,,North Pinellas News
-3.212.144.110,northraleightoday.com,https://www.facebook.com/North-Raleigh-Today-101883081216354/,North Raleigh Today
-3.212.144.110,northrichmondtoday.com,,
-3.212.144.110,northshenandoahnews.com,,
-3.212.144.110,northtidewaternews.com,,
-3.212.144.110,northtrianglenews.com,https://www.facebook.com/North-Triangle-News-105840757485319/,North Triangle News
-3.212.144.110,northwakenews.com,https://www.facebook.com/North-Wake-News-109237560477468/,North Wake News
-3.212.144.110,nwatlantanews.com,,
-3.212.144.110,nwgeorgianews.com,,
-3.212.144.110,ocalastandard.com,,Ocala Standard
-3.212.144.110,ohiovalleytimes.com,,
-3.212.144.110,okeechobeetimes.com,,Okeechobee Times
-3.212.144.110,oldnorthnews.com,https://www.facebook.com/Old-North-News-101380274600494/,Old North News
-3.212.144.110,onslownews.com,https://www.facebook.com/Onslow-News-111657603563549/,Onslow News
-3.212.144.110,orlandostandard.com,,Orlando Standard
-3.212.144.110,outerbankstimes.com,https://www.facebook.com/Outer-Banks-Times-103345204402491/,Outer Banks Times
-3.212.144.110,palmcoasttimes.com,,Palm Coast Times
-3.212.144.110,palmettostatenews.com,,
-3.212.144.110,panamacityreporter.com,,Panama City Reporter
-3.212.144.110,pascoreporter.com,,Pasco Reporter
-3.212.144.110,peachtreetimes.com,,
-3.212.144.110,peedeenews.com,,
-3.212.144.110,pensacolatimes.com,,Pensacola Times
-3.212.144.110,pinehursttoday.com,https://www.facebook.com/Pinehurst-Today-108624233872424/,Pinehurst Today
-3.212.144.110,pinellastimes.com,,Pinellas Times
-3.212.144.110,polktimes.com,,Polk Times
-3.212.144.110,princewilliamreporter.com,,
-3.212.144.110,randolphcountynews.com,https://www.facebook.com/Randolph-County-News-119232536138350/,Randolph County News
-3.212.144.110,richmondleader.com,,
-3.212.144.110,roanokesun.com,,
-3.212.144.110,rockymounttoday.com,https://www.facebook.com/Rocky-Mount-Today-115352959862275/,Rocky Mount Today
-3.212.144.110,romereporter.com,,
-3.212.144.110,rowannews.com,https://www.facebook.com/Rowan-News-106127457456478/,Rowan News
-3.212.144.110,sarasotareview.com,,Sarasota Review
-3.212.144.110,savannahstandard.com,,
-3.212.144.110,scmidlandnews.com,,
-3.212.144.110,scvanews.com,,
-3.212.144.110,seatlantanews.com,,
-3.212.144.110,segeorgianews.com,,
-3.212.144.110,senorthcarolinanews.com,https://www.facebook.com/SE-North-Carolina-News-110819213651995/,SE North Carolina News
-3.212.144.110,shenandoahvalleynews.com,,
-3.212.144.110,southashevillenews.com,https://www.facebook.com/South-Asheville-News-106387787430394/,South Asheville News
-3.212.144.110,southatlantanews.com,,
-3.212.144.110,southbrowardnews.com,,South Broward News
-3.212.144.110,southcharlottetoday.com,#N/A,South Charlotte Today
-3.212.144.110,southcharolettenews.com,#N/A,
-3.212.144.110,southernwvnews.com,,
-3.212.144.110,southfairfaxnews.com,,
-3.212.144.110,southfultontoday.com,,
-3.212.144.110,southgeorgiatimes.com,,
-3.212.144.110,southguilfordnews.com,https://www.facebook.com/South-Guilford-News-100112064728186/,South Guilford News
-3.212.144.110,southgwinnettnews.com,,
-3.212.144.110,southlaketoday.com,,South Lake Today
-3.212.144.110,southmecklenburgnews.com,https://www.facebook.com/South-Mecklenburg-News-100968904641995/,South Mecklenburg News
-3.212.144.110,southmianews.com,,South Miami-Dade News
-3.212.144.110,southncnews.com,https://www.facebook.com/South-North-Carolina-News-108664537201551/,South North Carolina News
-3.212.144.110,southnewcastlenews.com,https://www.facebook.com/South-New-Castle-News-103651217716865/,South New Castle News
-3.212.144.110,southorlandonews.com,,South Orlando News
-3.212.144.110,southpalmbeachtoday.com,,South Palm Beach Today
-3.212.144.110,southpinellastimes.com,,South Pinellas Times
-3.212.144.110,southraleighnews.com,https://www.facebook.com/South-Raleigh-News-122305189162080/,South Raleigh News
-3.212.144.110,southsidevanews.com,,
-3.212.144.110,southtidewaternews.com,,
-3.212.144.110,southtrianglenews.com,https://www.facebook.com/South-Triangle-News-119493679447597/,South Triangle News
-3.212.144.110,southwinstonsalemnews.com,https://www.facebook.com/South-Winston-Salem-News-119205412808145/,South Winston Salem News
-3.212.144.110,spartanburgreporter.com,,
-3.212.144.110,stpetestandard.com,,St. Pete Standard
-3.212.144.110,sumtertimes.com,,Sumter Times
-3.212.144.110,sunshinesentinel.com,,Sun Shine Sentinel
-3.212.144.110,sussexreview.com,https://www.facebook.com/Sussex-Review-111264033622037/,Sussex Review
-3.212.144.110,swgeorgianews.com,,
-3.212.144.110,swvirginianews.com,,
-3.212.144.110,tallahasseesun.com,,Tallahassee Sun
-3.212.144.110,tamparepublic.com,,Tampa Republic
-3.212.144.110,treasurecoastsun.com,,Treasure Coast Sun
-3.212.144.110,upperwestscnews.com,,
-3.212.144.110,upstatescnews.com,,
-3.212.144.110,warnerrobinstoday.com,,
-3.212.144.110,wcgeorgianews.com,,
-3.212.144.110,westatlantanews.com,,
-3.212.144.110,westflnews.com,,West Florida News
-3.212.144.110,westhillsboroughnews.com,,West Hillsborough News
-3.212.144.110,westlakenormannews.com,https://www.facebook.com/West-Lake-Norman-News-105785764154777/,West Lake Norman News
-3.212.144.110,westnovanews.com,,
-3.212.144.110,westvolusianews.com,,West Volusia News
-3.212.144.110,westwakenews.com,https://www.facebook.com/West-Wake-News-103362967734059/,West Wake News
-3.212.144.110,williamsburgsun.com,,
-3.212.144.110,winstonsalemtimes.com,https://www.facebook.com/Winston-Salem-Times-106600967406055/,Winston Salem Times
-3.212.144.110,wvheartlandnews.com,,
-3.212.144.110,yadkinvalleynews.com,https://www.facebook.com/Yadkin-Valley-News-123089249083536/,Yadkin Valley News
-3.213.234.4,abilenetimes.com,,Abilene Times
-3.213.234.4,amarillogazette.com,,Amarillo Gazette
-3.213.234.4,auburntimes.com,,
-3.213.234.4,austintxnews.com,,Austin News
-3.213.234.4,baldwintimes.com,,
-3.213.234.4,batonrougereporter.com,,
-3.213.234.4,bentontimes.com,,
-3.213.234.4,bluegrasstimes.com,https://business.facebook.com/Bluegrass-Times-105734507479060/?business_id=898179107217559,Bluegrass Times
-3.213.234.4,bowlinggreentoday.com,https://business.facebook.com/Bluegrass-Times-105734507479060/?business_id=898179107217559,Bowling Green Today
-3.213.234.4,centrallouisiananews.com,,
-3.213.234.4,centraltxnews.com,,Central Texas News
-3.213.234.4,centroplexnews.com,,Centroplex News
-3.213.234.4,clarksvilletimes.com,,
-3.213.234.4,collintimes.com,,Collin Times
-3.213.234.4,conchovalleynews.com,,Concho Valley News
-3.213.234.4,corpuschristisun.com,,Corpus Christi Sun
-3.213.234.4,dallascitywire.com,,Dallas City Wire
-3.213.234.4,decaturtimes.com,,
-3.213.234.4,eastdfwnews.com,,East DFW News
-3.213.234.4,easthoustonnews.com,,East Houston News
-3.213.234.4,eastkentuckytimes.com,https://business.facebook.com/East-Kentucky-Times-111352810245930/?business_id=898179107217559,East Kentucky Times
-3.213.234.4,eastlittlerocktimes.com,,
-3.213.234.4,eastlouisvillenews.com,https://business.facebook.com/East-Louisville-News-105968707454981/?business_id=898179107217559,East Louisville News
-3.213.234.4,eastpennyroyalnews.com,https://business.facebook.com/East-Pennyroyal-News-100193101372622/?business_id=898179107217559,East Pennyroyal News
-3.213.234.4,eastrgvnews.com,,East RGV News
-3.213.234.4,ecalabamanews.com,,
-3.213.234.4,ecmissnews.com,,
-3.213.234.4,ectexasnews.com,,East Central Texas News
-3.213.234.4,elizabethtowntimes.com,https://business.facebook.com/Elizabethtown-Times-102532901135113/?business_id=898179107217559,Elizabethtown Times
-3.213.234.4,elpasostandard.com,,El Paso Standard
-3.213.234.4,farwesttxnews.com,,Far West Texas News
-3.213.234.4,fayettevillestandard.com,,
-3.213.234.4,floridaparishnews.com,,
-3.213.234.4,forestcountrynews.com,,Forest Country News
-3.213.234.4,fortsmithtimes.com,,
-3.213.234.4,ftworthtimes.com,,Ft Worth Times
-3.213.234.4,gadsdentoday.com,,
-3.213.234.4,graysontimes.com,,Grayson Times
-3.213.234.4,gtrtimes.com,,
-3.213.234.4,hamiltonreporter.com,,
-3.213.234.4,hillcountrychronicle.com,,Hill Country Chronicle
-3.213.234.4,hindstoday.com,,
-3.213.234.4,hopkinsvilletimes.com,https://business.facebook.com/Hopkinsville-Times-112952850084678/?business_id=898179107217559,Hopkinsville Times
-3.213.234.4,hotspringstimes.com,,
-3.213.234.4,houmathibodauxnews.com,,
-3.213.234.4,houstonrepublic.com,,Houston Republic
-3.213.234.4,huntsvilleleader.com,,
-3.213.234.4,jacksonpurchasenews.com,https://business.facebook.com/Jackson-Purchase-News-110979343616674/?business_id=898179107217559,Jackson Purchase News
-3.213.234.4,jeffersonreporter.com,,
-3.213.234.4,johnsoncitytimes.com,,
-3.213.234.4,jonesborotimes.com,,
-3.213.234.4,kingsportreporter.com,,
-3.213.234.4,knoxtimes.com,,
-3.213.234.4,lafayettereporter.com,,
-3.213.234.4,laredotimes.com,,Laredo Times
-3.213.234.4,lightofbaldr.com,#N/A,
-3.213.234.4,lonestarstandard.com,,Lone Star Standard
-3.213.234.4,longviewtimes.com,,Longview Times
-3.213.234.4,louisvillecitywire.com,https://business.facebook.com/LouisvilleCityWire/?business_id=898179107217559,Louisville City Wire
-3.213.234.4,lowedeltanews.com,,
-3.213.234.4,lubbocktimes.com,,Lubbock Times
-3.213.234.4,magnoliastatenews.com,,
-3.213.234.4,memphisstandard.com,,
-3.213.234.4,metrolexnews.com,https://business.facebook.com/Metro-Lex-News-101214361284018/?business_id=898179107217559,Metro Lex News
-3.213.234.4,midcitytimes.com,,Mid City Times
-3.213.234.4,mobilecourant.com,,
-3.213.234.4,morristowntimes.com,,
-3.213.234.4,msgulfnews.com,,
-3.213.234.4,nashvillestandard.com,,
-3.213.234.4,naturalstatenews.com,,
-3.213.234.4,ncarkansasnews.com,,
-3.213.234.4,nckentuckynews.com,https://business.facebook.com/NC-Kentucky-News-111261930254860/?business_id=898179107217559,NC Kentucky News
-3.213.234.4,ncmissnews.com,,
-3.213.234.4,nctennnews.com,,
-3.213.234.4,nealabamanews.com,,
-3.213.234.4,nedallasnews.com,,NE Dallas News
-3.213.234.4,nekentuckynews.com,https://business.facebook.com/NE-Kentucky-News-110835553630870/?business_id=898179107217559,NE Kentucky News
-3.213.234.4,nelouisiananews.com,,
-3.213.234.4,nemissnews.com,,
-3.213.234.4,nenashvillenews.com,,
-3.213.234.4,netarrantnews.com,,NE Tarrant News
-3.213.234.4,nolareporter.com,,
-3.213.234.4,nortextimes.com,,Nortex Times
-3.213.234.4,northacadiananews.com,,
-3.213.234.4,northaustinnews.com,,North Austin News
-3.213.234.4,northbirminghamtimes.com,,
-3.213.234.4,northbluegrassnews.com,https://business.facebook.com/North-Bluegrass-News-102291344493013/?business_id=898179107217559,North Bluegrass News
-3.213.234.4,northcoastalnews.com,,North Coastal News
-3.213.234.4,northhoustonnews.com,,North Houston News
-3.213.234.4,northkentuckynews.com,https://business.facebook.com/North-Kentucky-News-112347873478666/?business_id=898179107217559,North Kentucky News
-3.213.234.4,northknoxnews.com,,
-3.213.234.4,northlittlerocktimes.com,,
-3.213.234.4,northsanantonionews.com,,North San Antonio News
-3.213.234.4,northshorelanews.com,,
-3.213.234.4,northtxnews.com,,North Texas News
-3.213.234.4,nwalabamanews.com,,
-3.213.234.4,nwarkansasnews.com,,
-3.213.234.4,nwhoustonnews.com,,NW Houston News
-3.213.234.4,nwkentuckynews.com,https://business.facebook.com/NW-Kentucky-News-105957117456175/?business_id=898179107217559,NW Kentucky News
-3.213.234.4,nwlouisiananews.com,,
-3.213.234.4,nwmissnews.com,,
-3.213.234.4,nwtennnews.com,,
-3.213.234.4,oxfordreporter.com,,
-3.213.234.4,panhandletimes.com,,Panhandle Times
-3.213.234.4,pelicanstatenews.com,,
-3.213.234.4,petroplexnews.com,,Petroplex News
-3.213.234.4,pinebelttimes.com,,
-3.213.234.4,pulaskitimes.com,,
-3.213.234.4,riverparishnews.com,,
-3.213.234.4,riverregiontimes.com,,
-3.213.234.4,rutherfordtimes.com,,
-3.213.234.4,sacorridornews.com,,San Antonio Corridor News
-3.213.234.4,sanantoniostandard.com,,San Antonio Standard
-3.213.234.4,scmissnews.com,,
-3.213.234.4,sctennnews.com,,
-3.213.234.4,sctexasnews.com,,SC Texas News
-3.213.234.4,sebluegrassnews.com,https://business.facebook.com/SE-Bluegrass-News-106004234118073/?business_id=898179107217559,SE Bluegrass News
-3.213.234.4,sedallasnews.com,,SE Dallas News
-3.213.234.4,sehoustonnews.com,,SE Houston News
-3.213.234.4,sekentuckynews.com,https://business.facebook.com/SE-Kentucky-News-102576881130573/?business_id=898179107217559,SE Kentucky News
-3.213.234.4,setennnews.com,,
-3.213.234.4,setexastimes.com,,SE Texas Times
-3.213.234.4,shelbyreporter.com,,
-3.213.234.4,shoalstoday.com,,
-3.213.234.4,shreveportreporter.com,,
-3.213.234.4,smokymountaintoday.com,,
-3.213.234.4,southalabamatimes.com,,
-3.213.234.4,southbirminghamtimes.com,,
-3.213.234.4,southbrazorianews.com,,South Brazoria News
-3.213.234.4,southcumberlandnews.com,,
-3.213.234.4,southdfwnews.com,,South DFW News
-3.213.234.4,southgalvestonnews.com,,South Galveston News
-3.213.234.4,southknoxnews.com,,
-3.213.234.4,southlouisiananews.com,,
-3.213.234.4,southsanantonionews.com,,South San Antonio News
-3.213.234.4,swarkansastimes.com,,
-3.213.234.4,swbluegrassnews.com,https://business.facebook.com/SW-Bluegrass-News-114038463309089/?business_id=898179107217559,SW Bluegrass News
-3.213.234.4,swdallasnews.com,,SW Dallas News
-3.213.234.4,swhoustonnews.com,,SW Houston News
-3.213.234.4,swlouisiananews.com,,
-3.213.234.4,swmissnews.com,,
-3.213.234.4,swtennnews.com,,
-3.213.234.4,tuscaloosaleader.com,,
-3.213.234.4,tylerreporter.com,,Tyler Reporter
-3.213.234.4,uppercumberlandtimes.com,,
-3.213.234.4,upperdeltanews.com,,
-3.213.234.4,uppereasttx.com,,Upper East Texas News
-3.213.234.4,volunteerstatenews.com,,
-3.213.234.4,wacoreporter.com,,Waco Reporter
-3.213.234.4,wcalabamanews.com,,
-3.213.234.4,wcmissnews.com,,
-3.213.234.4,wctexasnews.com,,WC Texas News
-3.213.234.4,westbanklanews.com,,
-3.213.234.4,westdfwnews.com,,West DFW News
-3.213.234.4,westhoustonnews.com,,West Houston News
-3.213.234.4,westpennyroyalnews.com,https://business.facebook.com/West-Pennyroyal-News-104155477637721/?business_id=898179107217559,West Pennyroyal News
-3.213.234.4,westrgvnews.com,,West RGV News
-3.213.234.4,westtxnews.com,,West Texas News
-3.213.234.4,williamsonnews.com,,
-3.213.234.4,wintergardentoday.com,,Winter Garden Today
-3.213.234.4,wiregrasstimes.com,,
-3.213.234.4,yellowhammertimes.com,,
-3.218.216.245,akronreporter.com,,
-3.218.216.245,andersonreporter.com,,
-3.218.216.245,annarbortimes.com,https://business.facebook.com/Ann-Arbor-Times-105059500884218/?business_id=898179107217559,Ann Arbor Times
-3.218.216.245,battlecreektimes.com,https://business.facebook.com/Battle-Creek-Times-101371024590467/?business_id=898179107217559,Battle Creek Times
-3.218.216.245,bloomingtonleader.com,,
-3.218.216.245,buckeyereporter.com,,
-3.218.216.245,butlercountytoday.com,,
-3.218.216.245,cantonreporter.com,,
-3.218.216.245,centralohiotoday.com,,
-3.218.216.245,centralwisconsinnews.com,,
-3.218.216.245,chippewavalleytimes.com,,
-3.218.216.245,cincyreporter.com,,
-3.218.216.245,clermonttimes.com,,
-3.218.216.245,clevelandreporter.com,,
-3.218.216.245,columbusstandard.com,,
-3.218.216.245,daytonreporter.com,,
-3.218.216.245,delcoreview.com,,
-3.218.216.245,detroitcitywire.com,https://business.facebook.com/Detroit-City-Wire-105304140860043/?business_id=898179107217559,Detroit City Wire
-3.218.216.245,downrivertoday.com,https://business.facebook.com/Downriver-Today-116730986374533/?business_id=898179107217559,Downriver Today
-3.218.216.245,eastclevelandnews.com,,
-3.218.216.245,easternwaynetoday.com,https://business.facebook.com/Eastern-Wayne-Today-100600154668579/?business_id=898179107217559,Eastern Wayne Today
-3.218.216.245,eastindynews.com,,
-3.218.216.245,eastmichigannews.com,https://business.facebook.com/East-Michigan-News-104854544261605/?business_id=898179107217559,East Michigan News
-3.218.216.245,eaststarknews.com,,
-3.218.216.245,ecindiananews.com,,
-3.218.216.245,ecohionews.com,,
-3.218.216.245,ecwisconsinnews.com,,
-3.218.216.245,elkharttimes.com,,
-3.218.216.245,fairfieldreporter.com,,
-3.218.216.245,findlaytimes.com,,
-3.218.216.245,fondulacnews.com,,
-3.218.216.245,foxcitiesnews.com,,
-3.218.216.245,ftwaynetimes.com,,
-3.218.216.245,geneseenews.com,https://business.facebook.com/Genesee-News-100698147991930/?business_id=898179107217559,Genesee News
-3.218.216.245,grandrapidsreporter.com,https://business.facebook.com/Grand-Rapids-Reporter-111393033542730/?business_id=898179107217559,Grand Rapids Reporter
-3.218.216.245,greatlakeswire.com,https://business.facebook.com/Great-Lakes-Wire-110870006973319/?business_id=898179107217559,Great Lakes Wire
-3.218.216.245,greenbayreporter.com,,
-3.218.216.245,greenecotimes.com,,
-3.218.216.245,hollandreporter.com,https://business.facebook.com/Holland-Reporter-101483974584819/?business_id=898179107217559,Holland Reporter
-3.218.216.245,hoosierstatetoday.com,,
-3.218.216.245,indystandard.com,,
-3.218.216.245,kalamazootimes.com,https://business.facebook.com/Kalamazoo-Times-109349107125073/?business_id=898179107217559,Kalamazoo Times
-3.218.216.245,kenoshareporter.com,,
-3.218.216.245,kentuckianatimes.com,,
-3.218.216.245,kokomostandard.com,,
-3.218.216.245,lafayettetimes.com,,
-3.218.216.245,lakecountytimes.com,,
-3.218.216.245,lansingsun.com,https://business.facebook.com/Lansing-Sun-118678892851412/?business_id=898179107217559,Lansing Sun
-3.218.216.245,lickingtoday.com,,
-3.218.216.245,limareporter.com,,
-3.218.216.245,livingstontoday.com,https://business.facebook.com/Livingston-Today-100486091352075/?business_id=898179107217559,Livingston Today
-3.218.216.245,loraintimes.com,,
-3.218.216.245,macombtoday.com,https://business.facebook.com/Macomb-Today-107874710608318/?business_id=898179107217559,Macomb Today
-3.218.216.245,madisonreporter.com,,
-3.218.216.245,mansfieldtimes.com,,
-3.218.216.245,marionmorrowtimes.com,,
-3.218.216.245,medinatoday.com,,
-3.218.216.245,micapitolnews.com,https://business.facebook.com/Capitol-News-119768806075523/?business_id=898179107217559,Capitol News
-3.218.216.245,mkecitywire.com,,
-3.218.216.245,mkenorth.com,,
-3.218.216.245,mkesouth.com,,
-3.218.216.245,monroereview.com,https://business.facebook.com/Monroe-Review-100470841353605/?business_id=898179107217559,Monroe Review
-3.218.216.245,munciereporter.com,,
-3.218.216.245,muskegonsun.com,https://business.facebook.com/Muskegon-Sun-115132053208625/?business_id=898179107217559,Muskegon Sun
-3.218.216.245,ncindiananews.com,,
-3.218.216.245,ncwisconsinnews.com,,
-3.218.216.245,nefranklinnews.com,,
-3.218.216.245,neindiananews.com,,
-3.218.216.245,neohiotimes.com,,
-3.218.216.245,newisconsinnews.com,,
-3.218.216.245,northcincynews.com,,
-3.218.216.245,northcolumbusnews.com,,
-3.218.216.245,northindynews.com,,
-3.218.216.245,northkentnews.com,https://business.facebook.com/North-Kent-MI-News-106957820699749/?business_id=898179107217559,North Kent News
-3.218.216.245,northmichigannews.com,https://business.facebook.com/North-Michigan-News-109368280456600/?business_id=898179107217559,North Michigan News
-3.218.216.245,northsummitnews.com,,
-3.218.216.245,northwoodsreporter.com,,
-3.218.216.245,novitimes.com,https://business.facebook.com/Novi-Times-103247554407002/?business_id=898179107217559,Novi Times
-3.218.216.245,nwfranklinnews.com,,
-3.218.216.245,nwohiotimes.com,,
-3.218.216.245,nwwaynenews.com,https://business.facebook.com/Northwest-Wayne-News-115031663212614/?business_id=898179107217559,Northwest Wayne News
-3.218.216.245,ozaukeetimes.com,,
-3.218.216.245,pontiactimes.com,https://business.facebook.com/Pontiac-Times-111550783569826/?business_id=898179107217559,Pontiac Times
-3.218.216.245,portagetimes.com,,
-3.218.216.245,racinesun.com,,
-3.218.216.245,scwisconsinnews.com,,
-3.218.216.245,segrandrapids.com,https://business.facebook.com/SE-Grand-Rapids-News-112969396760248/?business_id=898179107217559,SE Grand Rapids News
-3.218.216.245,seindiananews.com,,
-3.218.216.245,seoaklandnews.com,https://business.facebook.com/SE-Oakland-News-113424383380642/?business_id=898179107217559,SE Oakland News
-3.218.216.245,seohiotimes.com,,
-3.218.216.245,shelbyreview.com,https://business.facebook.com/Shelby-Review-116959709691346/?business_id=898179107217559,Shelby Review
-3.218.216.245,shiawasseetimes.com,https://business.facebook.com/Shiawassee-Times-104757504254810/?business_id=898179107217559,Shiawassee Times
-3.218.216.245,southbendtimes.com,,
-3.218.216.245,southcolumbusnews.com,,
-3.218.216.245,southcuyahoganews.com,,
-3.218.216.245,southernindianatoday.com,,
-3.218.216.245,southfranklinnews.com,,
-3.218.216.245,southindynews.com,,
-3.218.216.245,southkentnews.com,https://business.facebook.com/South-Kent-News-105842877478949/?business_id=898179107217559,South Kent News
-3.218.216.245,southmichigannews.com,https://business.facebook.com/South-Michigan-News-115775179810824/?business_id=898179107217559,South Michigan News
-3.218.216.245,southohionews.com,,
-3.218.216.245,southsummitnews.com,,
-3.218.216.245,sowisconsintimes.com,,
-3.218.216.245,stclairtoday.com,https://business.facebook.com/St-Clair-Today-114311866624505/?business_id=898179107217559,St. Clair Today
-3.218.216.245,stjoebentonharbor.com,https://business.facebook.com/St-Joe-Benton-Harbor-News-107715530622760/?business_id=898179107217559,St. Joe-Benton Harbor News
-3.218.216.245,sturgiscoldwaternews.com,https://business.facebook.com/Sturgis-Coldwater-News-104885500909554/?business_id=898179107217559,Sturgis-Coldwater News
-3.218.216.245,swindiananews.com,,
-3.218.216.245,swwisconsinnews.com,,
-3.218.216.245,theregionnews.com,,
-3.218.216.245,thesconi.com,,
-3.218.216.245,thumbreporter.com,https://business.facebook.com/Thumb-Reporter-108682560526571/?business_id=898179107217559,Thumb Reporter
-3.218.216.245,toledoreporter.com,,
-3.218.216.245,tricitysun.com,https://business.facebook.com/Tri-City-Sun-109273330467110/?business_id=898179107217559,Tri-City Sun
-3.218.216.245,triconews.com,,
-3.218.216.245,trumballnews.com,,
-3.218.216.245,tuscarawasnews.com,,
-3.218.216.245,upgazette.com,https://business.facebook.com/UP-Gazette-117321146322386/?business_id=898179107217559,UP Gazette
-3.218.216.245,vacationlandtimes.com,,
-3.218.216.245,warrenclintonnews.com,,
-3.218.216.245,warrensun.com,https://business.facebook.com/The-Warren-Sun-110015123724499/?business_id=898179107217559,The Warren Sun
-3.218.216.245,washingtoncotimes.com,,
-3.218.216.245,waterfordtoday.com,https://business.facebook.com/Waterford-Today-117537322966727/?business_id=898179107217559,Waterford Today
-3.218.216.245,waukeshatimes.com,,
-3.218.216.245,waynecountytoday.com,,
-3.218.216.245,wcindiananews.com,,
-3.218.216.245,wcmichigannews.com,https://business.facebook.com/West-Central-Michigan-News-112859156772301/?business_id=898179107217559,West Central Michigan News
-3.218.216.245,wcwisconsinnews.com,,
-3.218.216.245,westclevelandnews.com,,
-3.218.216.245,westernwaynetoday.com,https://business.facebook.com/Western-Wayne-Today-105039360886409/?business_id=898179107217559,Western Wayne Today
-3.218.216.245,westhamiltonnews.com,,
-3.218.216.245,westindynews.com,,
-3.218.216.245,westlucasnews.com,,
-3.218.216.245,weststarknews.com,,
-3.218.216.245,whitewatertimes.com,,
-3.218.216.245,youngstowntimes.com,,
-3.219.182.20,abqtimes.com,,ABQ Times
-3.219.182.20,adamscountytimes.com,,
-3.219.182.20,adareporter.com,,
-3.219.182.20,beehivestatenews.com,,
-3.219.182.20,bigskytimes.com,https://www.facebook.com/Big-Sky-Times-101042667988813/,Big Sky Times
-3.219.182.20,boisecitywire.com,,
-3.219.182.20,boulderleader.com,,
-3.219.182.20,cdareporter.com,,
-3.219.182.20,centennialstatenews.com,,
-3.219.182.20,centralcoloradonews.com,,
-3.219.182.20,centralidahotimes.com,,
-3.219.182.20,centralmontanatimes.com,https://www.facebook.com/Central-Montana-Times-104433430978464/,Central Montana Times
-3.219.182.20,centralutahnews.com,,
-3.219.182.20,centralwynews.com,,
-3.219.182.20,coconinonews.com,https://www.facebook.com/Coconino-News-106875424063358/,Coconino News
-3.219.182.20,davistimes.com,,
-3.219.182.20,denvercitywire.com,,
-3.219.182.20,eaglevalleytimes.com,,
-3.219.182.20,eastarapahoenews.com,,
-3.219.182.20,eastarizonanews.com,https://www.facebook.com/East-Arizona-News-107421190674893/,East Arizona News
-3.219.182.20,eastidahotimes.com,,
-3.219.182.20,eastnewmexiconews.com,,East New Mexico News
-3.219.182.20,eastslcnews.com,,
-3.219.182.20,enchantmentstatenews.com,,Enchantment State News
-3.219.182.20,equalitystatenews.com,,
-3.219.182.20,gemstatewire.com,,
-3.219.182.20,glaciercountrynews.com,https://www.facebook.com/Glacier-County-News-111596100255900/,Glacier Country News
-3.219.182.20,grandcanyontimes.com,https://www.facebook.com/Grand-Canyon-Times-103936177693945/,Grand Canyon Times
-3.219.182.20,grandjunctiontimes.com,,
-3.219.182.20,larimernews.com,,
-3.219.182.20,lasvegasrecord.com,,
-3.219.182.20,magicvalleytimes.com,,
-3.219.182.20,mohavetoday.com,https://www.facebook.com/Mohave-Today-106106917474658/,Mohave Today
-3.219.182.20,necoloradonews.com,,
-3.219.182.20,nemontananews.com,https://www.facebook.com/Northeast-Montana-News-100486024712531/,Northeast Montana News
-3.219.182.20,nenewmexiconews.com,,NE New Mexico News
-3.219.182.20,nevalleytimes.com,https://www.facebook.com/NE-Valley-Times-102939384461230/,NE Valley Times
-3.219.182.20,newyomingnews.com,,
-3.219.182.20,northidahotimes.com,,
-3.219.182.20,northjeffconews.com,,
-3.219.182.20,northnevadanews.com,,
-3.219.182.20,northpimanews.com,https://www.facebook.com/North-Pima-News-102790197809540/,North Pima News
-3.219.182.20,northutahnews.com,,
-3.219.182.20,northvegastimes.com,,
-3.219.182.20,nwclarknews.com,,
-3.219.182.20,nwmontananews.com,https://www.facebook.com/Northwest-Montana-News-105852244168652/,Northwest Montana News
-3.219.182.20,nwnewmexiconews.com,,NW New Mexico News
-3.219.182.20,nwvalleytimes.com,https://www.facebook.com/NW-Valley-Times-Arizona-116478283096686/,NW Valley Times
-3.219.182.20,nwwyomingnews.com,,
-3.219.182.20,phxreporter.com,https://www.facebook.com/PHX-Reporter-101826427907463/,PHX Reporter
-3.219.182.20,pinaltoday.com,https://www.facebook.com/PHX-Reporter-101826427907463/,Pinal Today
-3.219.182.20,pocatellotimes.com,,
-3.219.182.20,renoreporter.com,,
-3.219.182.20,sandovalnews.com,,Sandoval News
-3.219.182.20,santafestandard.com,,Santa Fe Standard
-3.219.182.20,searizonanews.com,https://www.facebook.com/SE-Arizona-News-105278744161657/,SE Arizona News
-3.219.182.20,secoloradonews.com,,
-3.219.182.20,sedenvernews.com,,
-3.219.182.20,semontananews.com,https://www.facebook.com/Southeast-Montana-News-108673553883558/,Southeast Montana News
-3.219.182.20,sevalleytimes.com,https://www.facebook.com/SE-Valley-Times-116771266400427/,SE Valley Times
-3.219.182.20,sevegasnews.com,,
-3.219.182.20,sewyomingnews.com,,
-3.219.182.20,silverstatetimes.com,,
-3.219.182.20,slctimes.com,,
-3.219.182.20,southabqnews.com,,South ABQ News
-3.219.182.20,southjeffconews.com,,
-3.219.182.20,southpimanews.com,https://www.facebook.com/South-Pima-News-115540836524090/,South Pima News
-3.219.182.20,southutahnews.com,,
-3.219.182.20,springstimes.com,,
-3.219.182.20,swarizonanews.com,https://www.facebook.com/SW-Arizona-News-105115704178015/,SW Arizona News
-3.219.182.20,swcoloradonews.com,,
-3.219.182.20,swmontanatimes.com,https://www.facebook.com/Southwest-Montana-News-100947377998569/,Southwest Montana News
-3.219.182.20,swnewmexiconews.com,,SW New Mexico News
-3.219.182.20,swvalleytimes.com,https://www.facebook.com/SW-Valley-Times-101232994634302/,SW Valley Times
-3.219.182.20,swvegasnews.com,,
-3.219.182.20,swwyomingnews.com,,
-3.219.182.20,treasurevalleytimes.com,,
-3.219.182.20,tucsonstandard.com,https://www.facebook.com/Tucson-Standard-115829333162253/,Tucson Standard
-3.219.182.20,utahvalleytimes.com,,
-3.219.182.20,washoenews.com,,
-3.219.182.20,wastachnews.com,,
-3.219.182.20,wcnewmexiconews.com,,WC New Mexico News
-3.219.182.20,webertimes.com,,
-3.219.182.20,westarapahoenews.com,,
-3.219.182.20,westslcnews.com,,
-3.219.182.20,yavapainews.com,https://www.facebook.com/Yavapai-News-115640873181490,Yavapai News
-3.219.182.20,yellowstonetimes.com,https://www.facebook.com/Yellowstone-Times-107523753999800/,Yellowstone Times
-3.224.13.68,amestoday.com,https://business.facebook.com/Ames-Today-101356211280133/?business_id=898179107217559,Ames Today
-3.224.13.68,anokatimes.com,https://business.facebook.com/Anoka-Times-103161674441007/?business_id=898179107217559,Anoka Times
-3.224.13.68,bransontimes.com,,
-3.224.13.68,capemonews.com,,
-3.224.13.68,cedarrapidstoday.com,https://business.facebook.com/Cedar-Rapids-Today-100591341357573/?business_id=898179107217559,Cedar Rapids Today
-3.224.13.68,centraliowatimes.com,https://business.facebook.com/Central-Iowa-Times-118311509573706/?business_id=898179107217559,Central Iowa Times
-3.224.13.68,centralmissourinews.com,,
-3.224.13.68,centralndnews.com,,
-3.224.13.68,centralsdnews.com,,
-3.224.13.68,centralstlnews.com,,
-3.224.13.68,clayreporter.com,,
-3.224.13.68,columbiamonews.com,,
-3.224.13.68,cornhuskerstatenews.com,,
-3.224.13.68,dakotatimes.com,https://business.facebook.com/Dakota-Times-101460081279893/?business_id=898179107217559,Dakota Times
-3.224.13.68,desmoinessun.com,https://business.facebook.com/Des-Moines-Sun-101958604552546/?business_id=898179107217559,Des Moines Sun
-3.224.13.68,dubuquetimes.com,https://business.facebook.com/Dubuque-Times-114048820002219/?business_id=898179107217559,Dubuque Times
-3.224.13.68,eastokcnews.com,,
-3.224.13.68,easttwincities.com,https://business.facebook.com/East-Twin-Cities-102017971223826/?business_id=898179107217559,East Twin Cities
-3.224.13.68,eastwichitatimes.com,,
-3.224.13.68,eciowanews.com,https://business.facebook.com/East-Central-Iowa-News-102928174455039/?business_id=898179107217559,East Central Iowa News
-3.224.13.68,eckansasnews.com,,
-3.224.13.68,ecnebraskanews.com,,
-3.224.13.68,ecoklahomanews.com,,
-3.224.13.68,fargostandard.com,,
-3.224.13.68,hawkeyereporter.com,https://www.facebook.com/Hawkeye-Reporter-110638887011923/,Hawkeye Reporter
-3.224.13.68,hutchtoday.com,,
-3.224.13.68,iowacitytoday.com,https://www.facebook.com/Iowa-City-Today-116453419760333/,Iowa City Today
-3.224.13.68,jeffcitynews.com,,
-3.224.13.68,jeffcotimes.com,,
-3.224.13.68,jocotoday.com,,
-3.224.13.68,kcreporter.com,,
-3.224.13.68,lawrencereporter.com,,
-3.224.13.68,minneapolisreview.com,https://business.facebook.com/Minneapolis-Review-102334997858514/?business_id=898179107217559,Minneapolis Review
-3.224.13.68,minnesotastatewire.com,,Minnesota State Wire
-3.224.13.68,nckansasnews.com,,
-3.224.13.68,ncminnesotanews.com,https://business.facebook.com/NC-Minnesota-News-100963467997125/?business_id=898179107217559,NC Minnesota News
-3.224.13.68,ncoklahomanews.com,,
-3.224.13.68,ndnorthnews.com,,
-3.224.13.68,neiowanews.com,https://www.facebook.com/NE-Iowa-News-115073833239021/,NE Iowa News
-3.224.13.68,nekansascitynews.com,,
-3.224.13.68,nekansasnews.com,,
-3.224.13.68,nemissourinews.com,,
-3.224.13.68,nenebraskanews.com,,
-3.224.13.68,nenorthdakotanews.com,,
-3.224.13.68,neoklahomanews.com,,
-3.224.13.68,nepanhandlenews.com,,
-3.224.13.68,nesdnews.com,,
-3.224.13.68,northdsmnews.com,https://www.facebook.com/North-DSM-News-102122281204867/,North DSM News
-3.224.13.68,northhennepinnews.com,https://business.facebook.com/North-Hennepin-News-111056933643780/?business_id=898179107217559,North Hennepin News
-3.224.13.68,northiowareporter.com,https://www.facebook.com/North-Iowa-Reporter-109005527181560/,North Iowa Reporter
-3.224.13.68,northokcnews.com,,
-3.224.13.68,northomahatimes.com,,
-3.224.13.68,northramseynews.com,https://business.facebook.com/North-Ramsey-News-102264164531959/?business_id=898179107217559,North Ramsey News
-3.224.13.68,northstlnews.com,,
-3.224.13.68,northtulsatoday.com,,
-3.224.13.68,northwichitanews.com,,
-3.224.13.68,nwiowanews.com,https://www.facebook.com/NW-Iowa-News-111152886960129/,NW Iowa News
-3.224.13.68,nwkansasnews.com,,
-3.224.13.68,nwminnesotanews.com,https://business.facebook.com/NW-Minnesota-News-104290047660202/?business_id=898179107217559,NW Minnesota News
-3.224.13.68,nwmissouritimes.com,,
-3.224.13.68,nwoklahomanews.com,,
-3.224.13.68,nwtwincities.com,https://business.facebook.com/NW-Twin-Cities-102320397859854/?business_id=898179107217559,NW Twin Cities
-3.224.13.68,okcstandard.com,,
-3.224.13.68,omaharecord.com,,
-3.224.13.68,peacegardennews.com,,
-3.224.13.68,plattenews.com,,
-3.224.13.68,riverbendtimes.com,https://www.facebook.com/River-Bend-Times-101474471267975/,River Bend Times
-3.224.13.68,rushmorestatenews.com,,
-3.224.13.68,sandhillstoday.com,,
-3.224.13.68,sckansasnews.com,,
-3.224.13.68,scminnesotanews.com,https://business.facebook.com/SC-Minnesota-News-113239810090802/?business_id=898179107217559,SC Minnesota News
-3.224.13.68,scmissourinews.com,,
-3.224.13.68,scnebraskanews.com,,
-3.224.13.68,scoklahomanews.com,,
-3.224.13.68,seiowanews.com,https://www.facebook.com/SE-Iowa-News-120767729327293/,SE Iowa News
-3.224.13.68,sekansascitynews.com,,
-3.224.13.68,sekansasnews.com,,
-3.224.13.68,seminnesotanews.com,https://business.facebook.com/SE-Minnesota-News-100587221369269/?business_id=898179107217559,SE Minnesota News
-3.224.13.68,semissourinews.com,,
-3.224.13.68,senebraskanews.com,,
-3.224.13.68,seoklahomanews.com,,
-3.224.13.68,sesdnews.com,,
-3.224.13.68,setwincities.com,https://business.facebook.com/SE-Twin-Cities-114885659925192/?business_id=898179107217559,SE Twin Cities
-3.224.13.68,showmestatetimes.com,,
-3.224.13.68,siouxcitytimes.com,https://www.facebook.com/Sioux-City-Times-102939701120339/,Sioux City Times
-3.224.13.68,siouxempiretoday.com,,
-3.224.13.68,soonerstatenews.com,,
-3.224.13.68,southdsmnews.com,https://www.facebook.com/South-DSM-News-107287824015641/,South DSM News
-3.224.13.68,southhennepinnews.com,https://business.facebook.com/South-Hennepin-News-102092271216305/?business_id=898179107217559,South Hennepin News
-3.224.13.68,southiowanews.com,https://www.facebook.com/South-Iowa-News-123170839086254/,South Iowa News
-3.224.13.68,southkcnews.com,,
-3.224.13.68,southokcnews.com,,
-3.224.13.68,southomahatimes.com,,
-3.224.13.68,southstlnews.com,,
-3.224.13.68,southtulsatoday.com,,
-3.224.13.68,southwichitanews.com,,
-3.224.13.68,springfieldstandard.com,,
-3.224.13.68,stcharlestimes.com,,
-3.224.13.68,stcloudsun.com,https://business.facebook.com/St-Cloud-Sun-110259113723778/?business_id=898179107217559,St. Cloud Sun
-3.224.13.68,stlouisreporter.com,,
-3.224.13.68,stlwestnews.com,,
-3.224.13.68,stpaulreporter.com,https://business.facebook.com/St-Paul-Reporter-110279643722234/?business_id=898179107217559,St. Paul Reporter
-3.224.13.68,sunflowerstatenews.com,,
-3.224.13.68,swiowatimes.com,https://www.facebook.com/SW-Iowa-Times-124062808996714/,SW Iowa Times
-3.224.13.68,swkansasnews.com,,
-3.224.13.68,swminnesotatoday.com,https://business.facebook.com/SW-Minnesota-Today-103649764391775/?business_id=898179107217559,SW Minnesota Today
-3.224.13.68,swmissourinews.com,,
-3.224.13.68,swoklahomanews.com,,
-3.224.13.68,topekasun.com,,
-3.224.13.68,tulsastandard.com,,
-3.224.13.68,waterlootimes.com,https://www.facebook.com/Waterloo-Times-112715190136235/,Waterloo Times
-3.224.13.68,wciowanews.com,https://www.facebook.com/WC-Iowa-News-107454624005217/,WC Iowa News
-3.224.13.68,wcminnesotanews.com,https://business.facebook.com/WC-Minnesota-News-102223587869263/?business_id=898179107217559,WC Minnesota News
-3.224.13.68,wcmissourinews.com,,
-3.224.13.68,westdsmnews.com,https://www.facebook.com/West-DSM-News-105518977533894/,West DSM News
-3.224.13.68,westernndnews.com,,
-3.224.13.68,westernsdnews.com,,
-3.224.13.68,weststlnews.com,,
-3.224.13.68,westtwincities.com,https://business.facebook.com/West-Twin-Cities-101347867958302/?business_id=898179107217559,West Twin Cities
-3.224.13.68,wichitastandard.com,,
-3.224.13.68,wyandottetimes.com,,
-35.170.88.147,carbondalereporter.com,https://www.facebook.com/Carbondale-Reporter-464661937077937/,Carbondale Reporter
-35.170.88.147,chambanasun.com,https://www.facebook.com/Chambana-Sun-399174026949103,Chambana Sun
-35.170.88.147,chicagocitywire.com,https://www.facebook.com/Chicago-City-Wire-145288335882139,Chicago City Wire
-35.170.88.147,dekalbtimes.com,https://www.facebook.com/DeKalb-Times-1650142418618920,DeKalb Times
-35.170.88.147,dupagepolicyjournal.com,https://www.facebook.com/DuPage-Policy-Journal-440850842779072,Dupage Policy Journal
-35.170.88.147,eastcentralreporter.com,https://www.facebook.com/East-Central-Reporter-1017551808288816,East Central Reporter
-35.170.88.147,galesburgreporter.com,https://www.facebook.com/GalesburgReporter/,Galesburg Reporter
-35.170.88.147,grundyreporter.com,https://www.facebook.com/Grundy-Reporter-111376299540998,Grundy Reporter
-35.170.88.147,illinoisvalleytimes.com,https://www.facebook.com/Illinois-Valley-Times-1544775089163392/,Illinois Valley Times
-35.170.88.147,kanecountyreporter.com,https://www.facebook.com/Kane-County-Reporter-113001215788482/,Kane County Reporter
-35.170.88.147,kankakeetimes.com,https://www.facebook.com/kankakeetimes,Kankakee Times
-35.170.88.147,kendallcountytimes.com,https://www.facebook.com/Kendall-County-Times-151364972111507,Kendall County Times
-35.170.88.147,lakecountygazette.com,https://www.facebook.com/Lake-County-Gazette-854479238006224,Lake County Gazette
-35.170.88.147,maconreporter.com,https://www.facebook.com/Macon-Reporter-915144198623038/,Macon Reporter
-35.170.88.147,mchenrytimes.com,https://www.facebook.com/McHenry-Times-1007855922605367,McHenry Times
-35.170.88.147,mcleancountytimes.com,https://www.facebook.com/McLean-County-Times-135405700298293,McLean County Times
-35.170.88.147,metroeastsun.com,https://www.facebook.com/metroeastsun,Metro East Sun
-35.170.88.147,northcooknews.com,https://www.facebook.com/North-Cook-News-1509066772752076,North Cook News
-35.170.88.147,northegyptnews.com,https://www.facebook.com/North-Egypt-News-2042181879445200/,North Egypt News
-35.170.88.147,nwillinoisnews.com,https://www.facebook.com/NW-Illinois-News-386241278410290,NW Illinois News
-35.170.88.147,peoriastandard.com,https://www.facebook.com/Peoria-Standard-469649066574953/,Peoria Standard
-35.170.88.147,prairiestatewire.com,https://www.facebook.com/Prairie-State-Wire-1121259961337606,Prairie State Wire
-35.170.88.147,quincyreporter.com,https://www.facebook.com/Quincy-Reporter-474680926275770/,Quincy Reporter
-35.170.88.147,rockfordsun.com,https://www.facebook.com/Rockford-Sun-232943860486838,Rockford Sun
-35.170.88.147,rockislandtoday.com,https://www.facebook.com/Rock-Island-Today-969031589833777,Rock Island Today
-35.170.88.147,sangamonsun.com,https://www.facebook.com/sangamonsun,Sangamon Sun
-35.170.88.147,seillinoisnews.com,https://www.facebook.com/Southeast-Illinois-News-1706595809591228/,SE Illinois News
-35.170.88.147,silnews.com,https://www.facebook.com/pg/SouthernILNews,Southern Illinois News
-35.170.88.147,southcentralreporter.com,https://www.facebook.com/South-Central-Reporter-500024923776682/,South Central Reporter
-35.170.88.147,southcooknews.com,https://www.facebook.com/South-Cook-News-231679387276536,South Cook News
-35.170.88.147,swillinoisnews.com,https://www.facebook.com/Southwest-Illinois-News-976392835784894,South West Illinois News
-35.170.88.147,westcentralreporter.com,https://www.facebook.com/West-Central-Reporter-605712169581530,West Central Reporter
-35.170.88.147,westcooknews.com,https://www.facebook.com/West-Cook-News-337385456906651,West Cook News
-35.170.88.147,willcountygazette.com,https://www.facebook.com/Will-County-Gazette-1595575670754558/,Will County Gazette
-52.7.148.177,louisianarecord.com,https://www.facebook.com/LouisianaRecord/,Louisiana Record
-52.7.148.177,setexasrecord.com,https://www.facebook.com/SETexasRecord/,Southeast Texas Record
-52.7.148.177,socalrecord.com,,Southern California Record
-52.7.148.177,pennrecord.com,https://www.facebook.com/pages/Pennsylvania-Record/338776239487764,Pennsylvania Record
-52.7.148.177,norcalrecord.com,https://www.facebook.com/Northern-California-Record-975849335817140/,Northern California Record
-52.7.148.177,wvrecord.com,https://www.facebook.com/WVRecord,West Virginia Record
-52.7.148.177,stlrecord.com,https://www.facebook.com/stlrecord,St. Louis Record
-52.7.148.177,legalnewsline.com,https://www.facebook.com/pages/Legal-Newsline/299588323424419,Legal Newsline
-52.7.148.177,cookcountyrecord.com,https://www.facebook.com/cookcountyrecord,Cook County Record
-52.7.148.177,flarecord.com,https://www.facebook.com/Florida-Record-772624976214511/,Florida Record
-52.7.148.177,madisonrecord.com,https://www.facebook.com/pages/MadisonSt-Clair-Record/164779816968453,Madison - St. Clair Record
+awsOrigin,domain,facebookUrl,siteName,twitterUrl,itunesAppStoreUrl
+3.212.144.110,aikentimes.com,,,,
+3.212.144.110,albanystandard.com,,,,
+3.212.144.110,alleghenyhighlandstoday.com,,,,
+3.212.144.110,ashevillereporter.com,https://www.facebook.com/Asheville-Reporter-120029399386332/,Asheville Reporter,,
+3.212.144.110,athensreporter.com,,,,
+3.212.144.110,atlstandard.com,,,,
+3.212.144.110,berkeleyleader.com,,,,
+3.212.144.110,bluestonenews.com,,,,
+3.212.144.110,brevardsun.com,,Brevard Sun,,
+3.212.144.110,burlingtonreporter.com,https://www.facebook.com/Burlington-Reporter-121484399239483/,Burlington Reporter,,
+3.212.144.110,cabarrustoday.com,https://www.facebook.com/Cabarrus-Today-110013390395328/,Cabarrus Today,,
+3.212.144.110,centralbrowardnews.com,,Central Broward News,,
+3.212.144.110,centralgeorgianews.com,,,,
+3.212.144.110,centralnovanews.com,,,,
+3.212.144.110,centralshenandoahnews.com,,,,
+3.212.144.110,centralvatimes.com,,,,
+3.212.144.110,chapelhillreview.com,https://www.facebook.com/Chapel-Hill-Review-103130714424239/,Chapel Hill Review,,
+3.212.144.110,charlestonleader.com,,,,
+3.212.144.110,charlestonreporter.com,,,,
+3.212.144.110,claycotimes.com,,Clay County Times,,
+3.212.144.110,coastalganews.com,,,,
+3.212.144.110,cobbreporter.com,,,,
+3.212.144.110,columbiastandard.com,,,,
+3.212.144.110,dekalbganews.com,,,,
+3.212.144.110,dorchestertoday.com,,,,
+3.212.144.110,durhamreporter.com,https://www.facebook.com/Durham-Reporter-118375432886638/,Durham Reporter,,
+3.212.144.110,duvaltimes.com,,Duval Times,,
+3.212.144.110,easternshoretimes.com,,,,
+3.212.144.110,easthillsboroughnews.com,,East Hillsborough News,,
+3.212.144.110,eastlakenormannews.com,https://www.facebook.com/East-Lake-Norman-News-105190370881365/,East Lake Norman News,,
+3.212.144.110,eastpanhandlenews.com,,East Panhandle News,,
+3.212.144.110,eastpanhandletimes.com,,,,
+3.212.144.110,eastvolusianews.com,,East Volusia News,,
+3.212.144.110,eastwaketimes.com,https://www.facebook.com/East-Wake-Times-109459453784640/,East Wake Times,,
+3.212.144.110,ecgeorgianews.com,,,,
+3.212.144.110,ecnorthcarolinanews.com,https://www.facebook.com/EC-North-Carolina-News-105550317511769/,EC North Carolina News,,
+3.212.144.110,ecvirginianews.com,,,,
+3.212.144.110,emeraldcoasttimes.com,,Emerald Coast Times,,
+3.212.144.110,fayettevilletoday.com,https://www.facebook.com/Fayetteville-Today-112462826815757/,Fayetteville Today,,
+3.212.144.110,firststatetimes.com,https://www.facebook.com/First-State-Times-111265990223655/,First State Times,,
+3.212.144.110,foothillsreview.com,https://www.facebook.com/Foothills-Review-101128717956444/,Foothills Review,,
+3.212.144.110,fredericksburgleader.com,,,,
+3.212.144.110,gastoniatimes.com,https://www.facebook.com/Gastonia-Times-119779936078342/,Gastonia Times,,
+3.212.144.110,gatewayreporter.com,,,,
+3.212.144.110,georgiamountainnews.com,,,,
+3.212.144.110,greensbororeporter.com,https://www.facebook.com/Greensboro-Reporter-116196246439218/,Greensboro Reporter,,
+3.212.144.110,greenvilleleader.com,,,,
+3.212.144.110,greenvillereporter.com,https://www.facebook.com/Greenville-Reporter-121924869195889/,Greenville Reporter,,
+3.212.144.110,henricotimes.com,,,,
+3.212.144.110,hernandoreporter.com,,Hernando Reporter,,
+3.212.144.110,hickorysun.com,https://www.facebook.com/Hickory-Sun-111121563617189/,Hickory Sun,,
+3.212.144.110,highcountrytimes.com,https://www.facebook.com/High-Country-Times-107671310631667/,High Country Times,,
+3.212.144.110,hiltonheadreporter.com,,,,
+3.212.144.110,huntingtontimes.com,,,,
+3.212.144.110,ibxnews.com,https://www.facebook.com/IBX-News-116157859776600/,IBX News,,
+3.212.144.110,injouercad.us,#N/A,,,
+3.212.144.110,johnstonreporter.com,https://www.facebook.com/Johnston-Reporter-113415450052248,Johnston Reporter,,
+3.212.144.110,kentcountytoday.com,https://www.facebook.com/Kent-County-Today-114894533256835/,Kent County Today,,
+3.212.144.110,keywestreporter.com,,Key West Reporter,,
+3.212.144.110,leetoday.com,,Lee Today,,
+3.212.144.110,lowerwestscnews.com,,,,
+3.212.144.110,lynchburgreporter.com,,,,
+3.212.144.110,macontimes.com,,,,
+3.212.144.110,manateereview.com,,Manatee Review,,
+3.212.144.110,miamicourant.com,,Miami Courant,,
+3.212.144.110,mountainstatetimes.com,,,,
+3.212.144.110,myrtlebeachleader.com,,,,
+3.212.144.110,nantahalanews.com,https://www.facebook.com/Nantahala-News-111249553604479/,Nantahala News,,
+3.212.144.110,naplesstandard.com,,Naples Standard,,
+3.212.144.110,naturecoasttimes.com,,Nature Coast Times,,
+3.212.144.110,ncfloridanews.com,,NC Florida News,,
+3.212.144.110,ncgeorgianews.com,,,,
+3.212.144.110,ncncnews.com,https://www.facebook.com/NC-North-Carolina-News-112558680139451/,NC North Carolina News,,
+3.212.144.110,ncsctimes.com,,,,
+3.212.144.110,ncunionnews.com,https://www.facebook.com/Union-News-114326133299310/,Union News,,
+3.212.144.110,ncwvnews.com,,,,
+3.212.144.110,neatlantanews.com,,,,
+3.212.144.110,nefloridanews.com,,NE Florida News,,
+3.212.144.110,nepiedmontnews.com,https://www.facebook.com/NE-Piedmont-News-108836913847873/,NE Piedmont News,,
+3.212.144.110,newrivervalleytimes.com,,,,
+3.212.144.110,northbrowardnews.com,,North Broward News,,
+3.212.144.110,northcharlottetoday.com,,North Charlotte Today,,
+3.212.144.110,northcharolettenews.com,,,,
+3.212.144.110,northernnecktimes.com,,,,
+3.212.144.110,northfairfaxnews.com,,,,
+3.212.144.110,northfultontoday.com,,,,
+3.212.144.110,northguilfordnews.com,https://www.facebook.com/North-Guilford-News-117744056288004/,North Guilford News,,
+3.212.144.110,northgwinnettnews.com,,,,
+3.212.144.110,northiredellnews.com,https://www.facebook.com/North-Iredell-News-118400609555835/,North Iredell News,,
+3.212.144.110,northlaketimes.com,,North Lake Times,,
+3.212.144.110,northmecklenburgnews.com,https://www.facebook.com/North-Mecklenburg-News-116572919739799,North Mecklenburg News,,
+3.212.144.110,northmianews.com,,North Miami-Dade News,,
+3.212.144.110,northnewcastlenews.com,https://www.facebook.com/North-New-Castle-News-106071607478194/,North New Castle News,,
+3.212.144.110,northorlandonews.com,,North Orlando News,,
+3.212.144.110,northpalmbeachtoday.com,,North Palm Beach Today,,
+3.212.144.110,northpanhandlenews.com,,North Panhandle News,,
+3.212.144.110,northpanhandletimes.com,,,,
+3.212.144.110,northpinellasnews.com,,North Pinellas News,,
+3.212.144.110,northraleightoday.com,https://www.facebook.com/North-Raleigh-Today-101883081216354/,North Raleigh Today,,
+3.212.144.110,northrichmondtoday.com,,,,
+3.212.144.110,northshenandoahnews.com,,,,
+3.212.144.110,northtidewaternews.com,,,,
+3.212.144.110,northtrianglenews.com,https://www.facebook.com/North-Triangle-News-105840757485319/,North Triangle News,,
+3.212.144.110,northwakenews.com,https://www.facebook.com/North-Wake-News-109237560477468/,North Wake News,,
+3.212.144.110,nwatlantanews.com,,,,
+3.212.144.110,nwgeorgianews.com,,,,
+3.212.144.110,ocalastandard.com,,Ocala Standard,,
+3.212.144.110,ohiovalleytimes.com,,,,
+3.212.144.110,okeechobeetimes.com,,Okeechobee Times,,
+3.212.144.110,oldnorthnews.com,https://www.facebook.com/Old-North-News-101380274600494/,Old North News,,
+3.212.144.110,onslownews.com,https://www.facebook.com/Onslow-News-111657603563549/,Onslow News,,
+3.212.144.110,orlandostandard.com,,Orlando Standard,,
+3.212.144.110,outerbankstimes.com,https://www.facebook.com/Outer-Banks-Times-103345204402491/,Outer Banks Times,,
+3.212.144.110,palmcoasttimes.com,,Palm Coast Times,,
+3.212.144.110,palmettostatenews.com,,,,
+3.212.144.110,panamacityreporter.com,,Panama City Reporter,,
+3.212.144.110,pascoreporter.com,,Pasco Reporter,,
+3.212.144.110,peachtreetimes.com,,,,
+3.212.144.110,peedeenews.com,,,,
+3.212.144.110,pensacolatimes.com,,Pensacola Times,,
+3.212.144.110,pinehursttoday.com,https://www.facebook.com/Pinehurst-Today-108624233872424/,Pinehurst Today,,
+3.212.144.110,pinellastimes.com,,Pinellas Times,,
+3.212.144.110,polktimes.com,,Polk Times,,
+3.212.144.110,princewilliamreporter.com,,,,
+3.212.144.110,randolphcountynews.com,https://www.facebook.com/Randolph-County-News-119232536138350/,Randolph County News,,
+3.212.144.110,richmondleader.com,,,,
+3.212.144.110,roanokesun.com,,,,
+3.212.144.110,rockymounttoday.com,https://www.facebook.com/Rocky-Mount-Today-115352959862275/,Rocky Mount Today,,
+3.212.144.110,romereporter.com,,,,
+3.212.144.110,rowannews.com,https://www.facebook.com/Rowan-News-106127457456478/,Rowan News,,
+3.212.144.110,sarasotareview.com,,Sarasota Review,,
+3.212.144.110,savannahstandard.com,,,,
+3.212.144.110,scmidlandnews.com,,,,
+3.212.144.110,scvanews.com,,,,
+3.212.144.110,seatlantanews.com,,,,
+3.212.144.110,segeorgianews.com,,,,
+3.212.144.110,senorthcarolinanews.com,https://www.facebook.com/SE-North-Carolina-News-110819213651995/,SE North Carolina News,,
+3.212.144.110,shenandoahvalleynews.com,,,,
+3.212.144.110,southashevillenews.com,https://www.facebook.com/South-Asheville-News-106387787430394/,South Asheville News,,
+3.212.144.110,southatlantanews.com,,,,
+3.212.144.110,southbrowardnews.com,,South Broward News,,
+3.212.144.110,southcharlottetoday.com,#N/A,South Charlotte Today,,
+3.212.144.110,southcharolettenews.com,#N/A,,,
+3.212.144.110,southernwvnews.com,,,,
+3.212.144.110,southfairfaxnews.com,,,,
+3.212.144.110,southfultontoday.com,,,,
+3.212.144.110,southgeorgiatimes.com,,,,
+3.212.144.110,southguilfordnews.com,https://www.facebook.com/South-Guilford-News-100112064728186/,South Guilford News,,
+3.212.144.110,southgwinnettnews.com,,,,
+3.212.144.110,southlaketoday.com,,South Lake Today,,
+3.212.144.110,southmecklenburgnews.com,https://www.facebook.com/South-Mecklenburg-News-100968904641995/,South Mecklenburg News,,
+3.212.144.110,southmianews.com,,South Miami-Dade News,,
+3.212.144.110,southncnews.com,https://www.facebook.com/South-North-Carolina-News-108664537201551/,South North Carolina News,,
+3.212.144.110,southnewcastlenews.com,https://www.facebook.com/South-New-Castle-News-103651217716865/,South New Castle News,,
+3.212.144.110,southorlandonews.com,,South Orlando News,,
+3.212.144.110,southpalmbeachtoday.com,,South Palm Beach Today,,
+3.212.144.110,southpinellastimes.com,,South Pinellas Times,,
+3.212.144.110,southraleighnews.com,https://www.facebook.com/South-Raleigh-News-122305189162080/,South Raleigh News,,
+3.212.144.110,southsidevanews.com,,,,
+3.212.144.110,southtidewaternews.com,,,,
+3.212.144.110,southtrianglenews.com,https://www.facebook.com/South-Triangle-News-119493679447597/,South Triangle News,,
+3.212.144.110,southwinstonsalemnews.com,https://www.facebook.com/South-Winston-Salem-News-119205412808145/,South Winston Salem News,,
+3.212.144.110,spartanburgreporter.com,,,,
+3.212.144.110,stpetestandard.com,,St. Pete Standard,,
+3.212.144.110,sumtertimes.com,,Sumter Times,,
+3.212.144.110,sunshinesentinel.com,,Sun Shine Sentinel,,
+3.212.144.110,sussexreview.com,https://www.facebook.com/Sussex-Review-111264033622037/,Sussex Review,,
+3.212.144.110,swgeorgianews.com,,,,
+3.212.144.110,swvirginianews.com,,,,
+3.212.144.110,tallahasseesun.com,,Tallahassee Sun,,
+3.212.144.110,tamparepublic.com,,Tampa Republic,,
+3.212.144.110,treasurecoastsun.com,,Treasure Coast Sun,,
+3.212.144.110,upperwestscnews.com,,,,
+3.212.144.110,upstatescnews.com,,,,
+3.212.144.110,warnerrobinstoday.com,,,,
+3.212.144.110,wcgeorgianews.com,,,,
+3.212.144.110,westatlantanews.com,,,,
+3.212.144.110,westflnews.com,,West Florida News,,
+3.212.144.110,westhillsboroughnews.com,,West Hillsborough News,,
+3.212.144.110,westlakenormannews.com,https://www.facebook.com/West-Lake-Norman-News-105785764154777/,West Lake Norman News,,
+3.212.144.110,westnovanews.com,,,,
+3.212.144.110,westvolusianews.com,,West Volusia News,,
+3.212.144.110,westwakenews.com,https://www.facebook.com/West-Wake-News-103362967734059/,West Wake News,,
+3.212.144.110,williamsburgsun.com,,,,
+3.212.144.110,winstonsalemtimes.com,https://www.facebook.com/Winston-Salem-Times-106600967406055/,Winston Salem Times,,
+3.212.144.110,wvheartlandnews.com,,,,
+3.212.144.110,yadkinvalleynews.com,https://www.facebook.com/Yadkin-Valley-News-123089249083536/,Yadkin Valley News,,
+3.213.234.4,abilenetimes.com,,Abilene Times,,
+3.213.234.4,amarillogazette.com,,Amarillo Gazette,,
+3.213.234.4,auburntimes.com,,,,
+3.213.234.4,austintxnews.com,,Austin News,,
+3.213.234.4,baldwintimes.com,,,,
+3.213.234.4,batonrougereporter.com,,,,
+3.213.234.4,bentontimes.com,,,,
+3.213.234.4,bluegrasstimes.com,https://business.facebook.com/Bluegrass-Times-105734507479060/?business_id=898179107217559,Bluegrass Times,,
+3.213.234.4,bowlinggreentoday.com,https://business.facebook.com/Bluegrass-Times-105734507479060/?business_id=898179107217559,Bowling Green Today,,
+3.213.234.4,centrallouisiananews.com,,,,
+3.213.234.4,centraltxnews.com,,Central Texas News,,
+3.213.234.4,centroplexnews.com,,Centroplex News,,
+3.213.234.4,clarksvilletimes.com,,,,
+3.213.234.4,collintimes.com,,Collin Times,,
+3.213.234.4,conchovalleynews.com,,Concho Valley News,,
+3.213.234.4,corpuschristisun.com,,Corpus Christi Sun,,
+3.213.234.4,dallascitywire.com,,Dallas City Wire,,
+3.213.234.4,decaturtimes.com,,,,
+3.213.234.4,eastdfwnews.com,,East DFW News,,
+3.213.234.4,easthoustonnews.com,,East Houston News,,
+3.213.234.4,eastkentuckytimes.com,https://business.facebook.com/East-Kentucky-Times-111352810245930/?business_id=898179107217559,East Kentucky Times,,
+3.213.234.4,eastlittlerocktimes.com,,,,
+3.213.234.4,eastlouisvillenews.com,https://business.facebook.com/East-Louisville-News-105968707454981/?business_id=898179107217559,East Louisville News,,
+3.213.234.4,eastpennyroyalnews.com,https://business.facebook.com/East-Pennyroyal-News-100193101372622/?business_id=898179107217559,East Pennyroyal News,,
+3.213.234.4,eastrgvnews.com,,East RGV News,,
+3.213.234.4,ecalabamanews.com,,,,
+3.213.234.4,ecmissnews.com,,,,
+3.213.234.4,ectexasnews.com,,East Central Texas News,,
+3.213.234.4,elizabethtowntimes.com,https://business.facebook.com/Elizabethtown-Times-102532901135113/?business_id=898179107217559,Elizabethtown Times,,
+3.213.234.4,elpasostandard.com,,El Paso Standard,,
+3.213.234.4,farwesttxnews.com,,Far West Texas News,,
+3.213.234.4,fayettevillestandard.com,,,,
+3.213.234.4,floridaparishnews.com,,,,
+3.213.234.4,forestcountrynews.com,,Forest Country News,,
+3.213.234.4,fortsmithtimes.com,,,,
+3.213.234.4,ftworthtimes.com,,Ft Worth Times,,
+3.213.234.4,gadsdentoday.com,,,,
+3.213.234.4,graysontimes.com,,Grayson Times,,
+3.213.234.4,gtrtimes.com,,,,
+3.213.234.4,hamiltonreporter.com,,,,
+3.213.234.4,hillcountrychronicle.com,,Hill Country Chronicle,,
+3.213.234.4,hindstoday.com,,,,
+3.213.234.4,hopkinsvilletimes.com,https://business.facebook.com/Hopkinsville-Times-112952850084678/?business_id=898179107217559,Hopkinsville Times,,
+3.213.234.4,hotspringstimes.com,,,,
+3.213.234.4,houmathibodauxnews.com,,,,
+3.213.234.4,houstonrepublic.com,,Houston Republic,,
+3.213.234.4,huntsvilleleader.com,,,,
+3.213.234.4,jacksonpurchasenews.com,https://business.facebook.com/Jackson-Purchase-News-110979343616674/?business_id=898179107217559,Jackson Purchase News,,
+3.213.234.4,jeffersonreporter.com,,,,
+3.213.234.4,johnsoncitytimes.com,,,,
+3.213.234.4,jonesborotimes.com,,,,
+3.213.234.4,kingsportreporter.com,,,,
+3.213.234.4,knoxtimes.com,,,,
+3.213.234.4,lafayettereporter.com,,,,
+3.213.234.4,laredotimes.com,,Laredo Times,,
+3.213.234.4,lightofbaldr.com,#N/A,,,
+3.213.234.4,lonestarstandard.com,,Lone Star Standard,,
+3.213.234.4,longviewtimes.com,,Longview Times,,
+3.213.234.4,louisvillecitywire.com,https://business.facebook.com/LouisvilleCityWire/?business_id=898179107217559,Louisville City Wire,,
+3.213.234.4,lowedeltanews.com,,,,
+3.213.234.4,lubbocktimes.com,,Lubbock Times,,
+3.213.234.4,magnoliastatenews.com,,,,
+3.213.234.4,memphisstandard.com,,,,
+3.213.234.4,metrolexnews.com,https://business.facebook.com/Metro-Lex-News-101214361284018/?business_id=898179107217559,Metro Lex News,,
+3.213.234.4,midcitytimes.com,,Mid City Times,,
+3.213.234.4,mobilecourant.com,,,,
+3.213.234.4,morristowntimes.com,,,,
+3.213.234.4,msgulfnews.com,,,,
+3.213.234.4,nashvillestandard.com,,,,
+3.213.234.4,naturalstatenews.com,,,,
+3.213.234.4,ncarkansasnews.com,,,,
+3.213.234.4,nckentuckynews.com,https://business.facebook.com/NC-Kentucky-News-111261930254860/?business_id=898179107217559,NC Kentucky News,,
+3.213.234.4,ncmissnews.com,,,,
+3.213.234.4,nctennnews.com,,,,
+3.213.234.4,nealabamanews.com,,,,
+3.213.234.4,nedallasnews.com,,NE Dallas News,,
+3.213.234.4,nekentuckynews.com,https://business.facebook.com/NE-Kentucky-News-110835553630870/?business_id=898179107217559,NE Kentucky News,,
+3.213.234.4,nelouisiananews.com,,,,
+3.213.234.4,nemissnews.com,,,,
+3.213.234.4,nenashvillenews.com,,,,
+3.213.234.4,netarrantnews.com,,NE Tarrant News,,
+3.213.234.4,nolareporter.com,,,,
+3.213.234.4,nortextimes.com,,Nortex Times,,
+3.213.234.4,northacadiananews.com,,,,
+3.213.234.4,northaustinnews.com,,North Austin News,,
+3.213.234.4,northbirminghamtimes.com,,,,
+3.213.234.4,northbluegrassnews.com,https://business.facebook.com/North-Bluegrass-News-102291344493013/?business_id=898179107217559,North Bluegrass News,,
+3.213.234.4,northcoastalnews.com,,North Coastal News,,
+3.213.234.4,northhoustonnews.com,,North Houston News,,
+3.213.234.4,northkentuckynews.com,https://business.facebook.com/North-Kentucky-News-112347873478666/?business_id=898179107217559,North Kentucky News,,
+3.213.234.4,northknoxnews.com,,,,
+3.213.234.4,northlittlerocktimes.com,,,,
+3.213.234.4,northsanantonionews.com,,North San Antonio News,,
+3.213.234.4,northshorelanews.com,,,,
+3.213.234.4,northtxnews.com,,North Texas News,,
+3.213.234.4,nwalabamanews.com,,,,
+3.213.234.4,nwarkansasnews.com,,,,
+3.213.234.4,nwhoustonnews.com,,NW Houston News,,
+3.213.234.4,nwkentuckynews.com,https://business.facebook.com/NW-Kentucky-News-105957117456175/?business_id=898179107217559,NW Kentucky News,,
+3.213.234.4,nwlouisiananews.com,,,,
+3.213.234.4,nwmissnews.com,,,,
+3.213.234.4,nwtennnews.com,,,,
+3.213.234.4,oxfordreporter.com,,,,
+3.213.234.4,panhandletimes.com,,Panhandle Times,,
+3.213.234.4,pelicanstatenews.com,,,,
+3.213.234.4,petroplexnews.com,,Petroplex News,,
+3.213.234.4,pinebelttimes.com,,,,
+3.213.234.4,pulaskitimes.com,,,,
+3.213.234.4,riverparishnews.com,,,,
+3.213.234.4,riverregiontimes.com,,,,
+3.213.234.4,rutherfordtimes.com,,,,
+3.213.234.4,sacorridornews.com,,San Antonio Corridor News,,
+3.213.234.4,sanantoniostandard.com,,San Antonio Standard,,
+3.213.234.4,scmissnews.com,,,,
+3.213.234.4,sctennnews.com,,,,
+3.213.234.4,sctexasnews.com,,SC Texas News,,
+3.213.234.4,sebluegrassnews.com,https://business.facebook.com/SE-Bluegrass-News-106004234118073/?business_id=898179107217559,SE Bluegrass News,,
+3.213.234.4,sedallasnews.com,,SE Dallas News,,
+3.213.234.4,sehoustonnews.com,,SE Houston News,,
+3.213.234.4,sekentuckynews.com,https://business.facebook.com/SE-Kentucky-News-102576881130573/?business_id=898179107217559,SE Kentucky News,,
+3.213.234.4,setennnews.com,,,,
+3.213.234.4,setexastimes.com,,SE Texas Times,,
+3.213.234.4,shelbyreporter.com,,,,
+3.213.234.4,shoalstoday.com,,,,
+3.213.234.4,shreveportreporter.com,,,,
+3.213.234.4,smokymountaintoday.com,,,,
+3.213.234.4,southalabamatimes.com,,,,
+3.213.234.4,southbirminghamtimes.com,,,,
+3.213.234.4,southbrazorianews.com,,South Brazoria News,,
+3.213.234.4,southcumberlandnews.com,,,,
+3.213.234.4,southdfwnews.com,,South DFW News,,
+3.213.234.4,southgalvestonnews.com,,South Galveston News,,
+3.213.234.4,southknoxnews.com,,,,
+3.213.234.4,southlouisiananews.com,,,,
+3.213.234.4,southsanantonionews.com,,South San Antonio News,,
+3.213.234.4,swarkansastimes.com,,,,
+3.213.234.4,swbluegrassnews.com,https://business.facebook.com/SW-Bluegrass-News-114038463309089/?business_id=898179107217559,SW Bluegrass News,,
+3.213.234.4,swdallasnews.com,,SW Dallas News,,
+3.213.234.4,swhoustonnews.com,,SW Houston News,,
+3.213.234.4,swlouisiananews.com,,,,
+3.213.234.4,swmissnews.com,,,,
+3.213.234.4,swtennnews.com,,,,
+3.213.234.4,tuscaloosaleader.com,,,,
+3.213.234.4,tylerreporter.com,,Tyler Reporter,,
+3.213.234.4,uppercumberlandtimes.com,,,,
+3.213.234.4,upperdeltanews.com,,,,
+3.213.234.4,uppereasttx.com,,Upper East Texas News,,
+3.213.234.4,volunteerstatenews.com,,,,
+3.213.234.4,wacoreporter.com,,Waco Reporter,,
+3.213.234.4,wcalabamanews.com,,,,
+3.213.234.4,wcmissnews.com,,,,
+3.213.234.4,wctexasnews.com,,WC Texas News,,
+3.213.234.4,westbanklanews.com,,,,
+3.213.234.4,westdfwnews.com,,West DFW News,,
+3.213.234.4,westhoustonnews.com,,West Houston News,,
+3.213.234.4,westpennyroyalnews.com,https://business.facebook.com/West-Pennyroyal-News-104155477637721/?business_id=898179107217559,West Pennyroyal News,,
+3.213.234.4,westrgvnews.com,,West RGV News,,
+3.213.234.4,westtxnews.com,,West Texas News,,
+3.213.234.4,williamsonnews.com,,,,
+3.213.234.4,wintergardentoday.com,,Winter Garden Today,,
+3.213.234.4,wiregrasstimes.com,,,,
+3.213.234.4,yellowhammertimes.com,,,,
+3.218.216.245,akronreporter.com,,,,
+3.218.216.245,andersonreporter.com,,,,
+3.218.216.245,annarbortimes.com,https://business.facebook.com/Ann-Arbor-Times-105059500884218/?business_id=898179107217559,Ann Arbor Times,,
+3.218.216.245,battlecreektimes.com,https://business.facebook.com/Battle-Creek-Times-101371024590467/?business_id=898179107217559,Battle Creek Times,,
+3.218.216.245,bloomingtonleader.com,,,,
+3.218.216.245,buckeyereporter.com,,,,
+3.218.216.245,butlercountytoday.com,,,,
+3.218.216.245,cantonreporter.com,,,,
+3.218.216.245,centralohiotoday.com,,,,
+3.218.216.245,centralwisconsinnews.com,,,,
+3.218.216.245,chippewavalleytimes.com,,,,
+3.218.216.245,cincyreporter.com,,,,
+3.218.216.245,clermonttimes.com,,,,
+3.218.216.245,clevelandreporter.com,,,,
+3.218.216.245,columbusstandard.com,,,,
+3.218.216.245,daytonreporter.com,,,,
+3.218.216.245,delcoreview.com,,,,
+3.218.216.245,detroitcitywire.com,https://business.facebook.com/Detroit-City-Wire-105304140860043/?business_id=898179107217559,Detroit City Wire,,
+3.218.216.245,downrivertoday.com,https://business.facebook.com/Downriver-Today-116730986374533/?business_id=898179107217559,Downriver Today,,
+3.218.216.245,eastclevelandnews.com,,,,
+3.218.216.245,easternwaynetoday.com,https://business.facebook.com/Eastern-Wayne-Today-100600154668579/?business_id=898179107217559,Eastern Wayne Today,,
+3.218.216.245,eastindynews.com,,,,
+3.218.216.245,eastmichigannews.com,https://business.facebook.com/East-Michigan-News-104854544261605/?business_id=898179107217559,East Michigan News,,
+3.218.216.245,eaststarknews.com,,,,
+3.218.216.245,ecindiananews.com,,,,
+3.218.216.245,ecohionews.com,,,,
+3.218.216.245,ecwisconsinnews.com,,,,
+3.218.216.245,elkharttimes.com,,,,
+3.218.216.245,fairfieldreporter.com,,,,
+3.218.216.245,findlaytimes.com,,,,
+3.218.216.245,fondulacnews.com,,,,
+3.218.216.245,foxcitiesnews.com,,,,
+3.218.216.245,ftwaynetimes.com,,,,
+3.218.216.245,geneseenews.com,https://business.facebook.com/Genesee-News-100698147991930/?business_id=898179107217559,Genesee News,,
+3.218.216.245,grandrapidsreporter.com,https://business.facebook.com/Grand-Rapids-Reporter-111393033542730/?business_id=898179107217559,Grand Rapids Reporter,,
+3.218.216.245,greatlakeswire.com,https://business.facebook.com/Great-Lakes-Wire-110870006973319/?business_id=898179107217559,Great Lakes Wire,,
+3.218.216.245,greenbayreporter.com,,,,
+3.218.216.245,greenecotimes.com,,,,
+3.218.216.245,hollandreporter.com,https://business.facebook.com/Holland-Reporter-101483974584819/?business_id=898179107217559,Holland Reporter,,
+3.218.216.245,hoosierstatetoday.com,,,,
+3.218.216.245,indystandard.com,,,,
+3.218.216.245,kalamazootimes.com,https://business.facebook.com/Kalamazoo-Times-109349107125073/?business_id=898179107217559,Kalamazoo Times,,
+3.218.216.245,kenoshareporter.com,,,,
+3.218.216.245,kentuckianatimes.com,,,,
+3.218.216.245,kokomostandard.com,,,,
+3.218.216.245,lafayettetimes.com,,,,
+3.218.216.245,lakecountytimes.com,,,,
+3.218.216.245,lansingsun.com,https://business.facebook.com/Lansing-Sun-118678892851412/?business_id=898179107217559,Lansing Sun,,
+3.218.216.245,lickingtoday.com,,,,
+3.218.216.245,limareporter.com,,,,
+3.218.216.245,livingstontoday.com,https://business.facebook.com/Livingston-Today-100486091352075/?business_id=898179107217559,Livingston Today,,
+3.218.216.245,loraintimes.com,,,,
+3.218.216.245,macombtoday.com,https://business.facebook.com/Macomb-Today-107874710608318/?business_id=898179107217559,Macomb Today,,
+3.218.216.245,madisonreporter.com,,,,
+3.218.216.245,mansfieldtimes.com,,,,
+3.218.216.245,marionmorrowtimes.com,,,,
+3.218.216.245,medinatoday.com,,,,
+3.218.216.245,micapitolnews.com,https://business.facebook.com/Capitol-News-119768806075523/?business_id=898179107217559,Capitol News,,
+3.218.216.245,mkecitywire.com,,,,
+3.218.216.245,mkenorth.com,,,,
+3.218.216.245,mkesouth.com,,,,
+3.218.216.245,monroereview.com,https://business.facebook.com/Monroe-Review-100470841353605/?business_id=898179107217559,Monroe Review,,
+3.218.216.245,munciereporter.com,,,,
+3.218.216.245,muskegonsun.com,https://business.facebook.com/Muskegon-Sun-115132053208625/?business_id=898179107217559,Muskegon Sun,,
+3.218.216.245,ncindiananews.com,,,,
+3.218.216.245,ncwisconsinnews.com,,,,
+3.218.216.245,nefranklinnews.com,,,,
+3.218.216.245,neindiananews.com,,,,
+3.218.216.245,neohiotimes.com,,,,
+3.218.216.245,newisconsinnews.com,,,,
+3.218.216.245,northcincynews.com,,,,
+3.218.216.245,northcolumbusnews.com,,,,
+3.218.216.245,northindynews.com,,,,
+3.218.216.245,northkentnews.com,https://business.facebook.com/North-Kent-MI-News-106957820699749/?business_id=898179107217559,North Kent News,,
+3.218.216.245,northmichigannews.com,https://business.facebook.com/North-Michigan-News-109368280456600/?business_id=898179107217559,North Michigan News,,
+3.218.216.245,northsummitnews.com,,,,
+3.218.216.245,northwoodsreporter.com,,,,
+3.218.216.245,novitimes.com,https://business.facebook.com/Novi-Times-103247554407002/?business_id=898179107217559,Novi Times,,
+3.218.216.245,nwfranklinnews.com,,,,
+3.218.216.245,nwohiotimes.com,,,,
+3.218.216.245,nwwaynenews.com,https://business.facebook.com/Northwest-Wayne-News-115031663212614/?business_id=898179107217559,Northwest Wayne News,,
+3.218.216.245,ozaukeetimes.com,,,,
+3.218.216.245,pontiactimes.com,https://business.facebook.com/Pontiac-Times-111550783569826/?business_id=898179107217559,Pontiac Times,,
+3.218.216.245,portagetimes.com,,,,
+3.218.216.245,racinesun.com,,,,
+3.218.216.245,scwisconsinnews.com,,,,
+3.218.216.245,segrandrapids.com,https://business.facebook.com/SE-Grand-Rapids-News-112969396760248/?business_id=898179107217559,SE Grand Rapids News,,
+3.218.216.245,seindiananews.com,,,,
+3.218.216.245,seoaklandnews.com,https://business.facebook.com/SE-Oakland-News-113424383380642/?business_id=898179107217559,SE Oakland News,,
+3.218.216.245,seohiotimes.com,,,,
+3.218.216.245,shelbyreview.com,https://business.facebook.com/Shelby-Review-116959709691346/?business_id=898179107217559,Shelby Review,,
+3.218.216.245,shiawasseetimes.com,https://business.facebook.com/Shiawassee-Times-104757504254810/?business_id=898179107217559,Shiawassee Times,,
+3.218.216.245,southbendtimes.com,,,,
+3.218.216.245,southcolumbusnews.com,,,,
+3.218.216.245,southcuyahoganews.com,,,,
+3.218.216.245,southernindianatoday.com,,,,
+3.218.216.245,southfranklinnews.com,,,,
+3.218.216.245,southindynews.com,,,,
+3.218.216.245,southkentnews.com,https://business.facebook.com/South-Kent-News-105842877478949/?business_id=898179107217559,South Kent News,,
+3.218.216.245,southmichigannews.com,https://business.facebook.com/South-Michigan-News-115775179810824/?business_id=898179107217559,South Michigan News,,
+3.218.216.245,southohionews.com,,,,
+3.218.216.245,southsummitnews.com,,,,
+3.218.216.245,sowisconsintimes.com,,,,
+3.218.216.245,stclairtoday.com,https://business.facebook.com/St-Clair-Today-114311866624505/?business_id=898179107217559,St. Clair Today,,
+3.218.216.245,stjoebentonharbor.com,https://business.facebook.com/St-Joe-Benton-Harbor-News-107715530622760/?business_id=898179107217559,St. Joe-Benton Harbor News,,
+3.218.216.245,sturgiscoldwaternews.com,https://business.facebook.com/Sturgis-Coldwater-News-104885500909554/?business_id=898179107217559,Sturgis-Coldwater News,,
+3.218.216.245,swindiananews.com,,,,
+3.218.216.245,swwisconsinnews.com,,,,
+3.218.216.245,theregionnews.com,,,,
+3.218.216.245,thesconi.com,,,,
+3.218.216.245,thumbreporter.com,https://business.facebook.com/Thumb-Reporter-108682560526571/?business_id=898179107217559,Thumb Reporter,,
+3.218.216.245,toledoreporter.com,,,,
+3.218.216.245,tricitysun.com,https://business.facebook.com/Tri-City-Sun-109273330467110/?business_id=898179107217559,Tri-City Sun,,
+3.218.216.245,triconews.com,,,,
+3.218.216.245,trumballnews.com,,,,
+3.218.216.245,tuscarawasnews.com,,,,
+3.218.216.245,upgazette.com,https://business.facebook.com/UP-Gazette-117321146322386/?business_id=898179107217559,UP Gazette,,
+3.218.216.245,vacationlandtimes.com,,,,
+3.218.216.245,warrenclintonnews.com,,,,
+3.218.216.245,warrensun.com,https://business.facebook.com/The-Warren-Sun-110015123724499/?business_id=898179107217559,The Warren Sun,,
+3.218.216.245,washingtoncotimes.com,,,,
+3.218.216.245,waterfordtoday.com,https://business.facebook.com/Waterford-Today-117537322966727/?business_id=898179107217559,Waterford Today,,
+3.218.216.245,waukeshatimes.com,,,,
+3.218.216.245,waynecountytoday.com,,,,
+3.218.216.245,wcindiananews.com,,,,
+3.218.216.245,wcmichigannews.com,https://business.facebook.com/West-Central-Michigan-News-112859156772301/?business_id=898179107217559,West Central Michigan News,,
+3.218.216.245,wcwisconsinnews.com,,,,
+3.218.216.245,westclevelandnews.com,,,,
+3.218.216.245,westernwaynetoday.com,https://business.facebook.com/Western-Wayne-Today-105039360886409/?business_id=898179107217559,Western Wayne Today,,
+3.218.216.245,westhamiltonnews.com,,,,
+3.218.216.245,westindynews.com,,,,
+3.218.216.245,westlucasnews.com,,,,
+3.218.216.245,weststarknews.com,,,,
+3.218.216.245,whitewatertimes.com,,,,
+3.218.216.245,youngstowntimes.com,,,,
+3.219.182.20,abqtimes.com,,ABQ Times,,
+3.219.182.20,adamscountytimes.com,,,,
+3.219.182.20,adareporter.com,,,,
+3.219.182.20,beehivestatenews.com,,,,
+3.219.182.20,bigskytimes.com,https://www.facebook.com/Big-Sky-Times-101042667988813/,Big Sky Times,,
+3.219.182.20,boisecitywire.com,,,,
+3.219.182.20,boulderleader.com,,,,
+3.219.182.20,cdareporter.com,,,,
+3.219.182.20,centennialstatenews.com,,,,
+3.219.182.20,centralcoloradonews.com,,,,
+3.219.182.20,centralidahotimes.com,,,,
+3.219.182.20,centralmontanatimes.com,https://www.facebook.com/Central-Montana-Times-104433430978464/,Central Montana Times,,
+3.219.182.20,centralutahnews.com,,,,
+3.219.182.20,centralwynews.com,,,,
+3.219.182.20,coconinonews.com,https://www.facebook.com/Coconino-News-106875424063358/,Coconino News,,
+3.219.182.20,davistimes.com,,,,
+3.219.182.20,denvercitywire.com,,,,
+3.219.182.20,eaglevalleytimes.com,,,,
+3.219.182.20,eastarapahoenews.com,,,,
+3.219.182.20,eastarizonanews.com,https://www.facebook.com/East-Arizona-News-107421190674893/,East Arizona News,,
+3.219.182.20,eastidahotimes.com,,,,
+3.219.182.20,eastnewmexiconews.com,,East New Mexico News,,
+3.219.182.20,eastslcnews.com,,,,
+3.219.182.20,enchantmentstatenews.com,,Enchantment State News,,
+3.219.182.20,equalitystatenews.com,,,,
+3.219.182.20,gemstatewire.com,,,,
+3.219.182.20,glaciercountrynews.com,https://www.facebook.com/Glacier-County-News-111596100255900/,Glacier Country News,,
+3.219.182.20,grandcanyontimes.com,https://www.facebook.com/Grand-Canyon-Times-103936177693945/,Grand Canyon Times,,
+3.219.182.20,grandjunctiontimes.com,,,,
+3.219.182.20,larimernews.com,,,,
+3.219.182.20,lasvegasrecord.com,,,,
+3.219.182.20,magicvalleytimes.com,,,,
+3.219.182.20,mohavetoday.com,https://www.facebook.com/Mohave-Today-106106917474658/,Mohave Today,,
+3.219.182.20,necoloradonews.com,,,,
+3.219.182.20,nemontananews.com,https://www.facebook.com/Northeast-Montana-News-100486024712531/,Northeast Montana News,,
+3.219.182.20,nenewmexiconews.com,,NE New Mexico News,,
+3.219.182.20,nevalleytimes.com,https://www.facebook.com/NE-Valley-Times-102939384461230/,NE Valley Times,,
+3.219.182.20,newyomingnews.com,,,,
+3.219.182.20,northidahotimes.com,,,,
+3.219.182.20,northjeffconews.com,,,,
+3.219.182.20,northnevadanews.com,,,,
+3.219.182.20,northpimanews.com,https://www.facebook.com/North-Pima-News-102790197809540/,North Pima News,,
+3.219.182.20,northutahnews.com,,,,
+3.219.182.20,northvegastimes.com,,,,
+3.219.182.20,nwclarknews.com,,,,
+3.219.182.20,nwmontananews.com,https://www.facebook.com/Northwest-Montana-News-105852244168652/,Northwest Montana News,,
+3.219.182.20,nwnewmexiconews.com,,NW New Mexico News,,
+3.219.182.20,nwvalleytimes.com,https://www.facebook.com/NW-Valley-Times-Arizona-116478283096686/,NW Valley Times,,
+3.219.182.20,nwwyomingnews.com,,,,
+3.219.182.20,phxreporter.com,https://www.facebook.com/PHX-Reporter-101826427907463/,PHX Reporter,,
+3.219.182.20,pinaltoday.com,https://www.facebook.com/PHX-Reporter-101826427907463/,Pinal Today,,
+3.219.182.20,pocatellotimes.com,,,,
+3.219.182.20,renoreporter.com,,,,
+3.219.182.20,sandovalnews.com,,Sandoval News,,
+3.219.182.20,santafestandard.com,,Santa Fe Standard,,
+3.219.182.20,searizonanews.com,https://www.facebook.com/SE-Arizona-News-105278744161657/,SE Arizona News,,
+3.219.182.20,secoloradonews.com,,,,
+3.219.182.20,sedenvernews.com,,,,
+3.219.182.20,semontananews.com,https://www.facebook.com/Southeast-Montana-News-108673553883558/,Southeast Montana News,,
+3.219.182.20,sevalleytimes.com,https://www.facebook.com/SE-Valley-Times-116771266400427/,SE Valley Times,,
+3.219.182.20,sevegasnews.com,,,,
+3.219.182.20,sewyomingnews.com,,,,
+3.219.182.20,silverstatetimes.com,,,,
+3.219.182.20,slctimes.com,,,,
+3.219.182.20,southabqnews.com,,South ABQ News,,
+3.219.182.20,southjeffconews.com,,,,
+3.219.182.20,southpimanews.com,https://www.facebook.com/South-Pima-News-115540836524090/,South Pima News,,
+3.219.182.20,southutahnews.com,,,,
+3.219.182.20,springstimes.com,,,,
+3.219.182.20,swarizonanews.com,https://www.facebook.com/SW-Arizona-News-105115704178015/,SW Arizona News,,
+3.219.182.20,swcoloradonews.com,,,,
+3.219.182.20,swmontanatimes.com,https://www.facebook.com/Southwest-Montana-News-100947377998569/,Southwest Montana News,,
+3.219.182.20,swnewmexiconews.com,,SW New Mexico News,,
+3.219.182.20,swvalleytimes.com,https://www.facebook.com/SW-Valley-Times-101232994634302/,SW Valley Times,,
+3.219.182.20,swvegasnews.com,,,,
+3.219.182.20,swwyomingnews.com,,,,
+3.219.182.20,treasurevalleytimes.com,,,,
+3.219.182.20,tucsonstandard.com,https://www.facebook.com/Tucson-Standard-115829333162253/,Tucson Standard,,
+3.219.182.20,utahvalleytimes.com,,,,
+3.219.182.20,washoenews.com,,,,
+3.219.182.20,wastachnews.com,,,,
+3.219.182.20,wcnewmexiconews.com,,WC New Mexico News,,
+3.219.182.20,webertimes.com,,,,
+3.219.182.20,westarapahoenews.com,,,,
+3.219.182.20,westslcnews.com,,,,
+3.219.182.20,yavapainews.com,https://www.facebook.com/Yavapai-News-115640873181490,Yavapai News,,
+3.219.182.20,yellowstonetimes.com,https://www.facebook.com/Yellowstone-Times-107523753999800/,Yellowstone Times,,
+3.224.13.68,amestoday.com,https://business.facebook.com/Ames-Today-101356211280133/?business_id=898179107217559,Ames Today,,
+3.224.13.68,anokatimes.com,https://business.facebook.com/Anoka-Times-103161674441007/?business_id=898179107217559,Anoka Times,,
+3.224.13.68,bransontimes.com,,,,
+3.224.13.68,capemonews.com,,,,
+3.224.13.68,cedarrapidstoday.com,https://business.facebook.com/Cedar-Rapids-Today-100591341357573/?business_id=898179107217559,Cedar Rapids Today,,
+3.224.13.68,centraliowatimes.com,https://business.facebook.com/Central-Iowa-Times-118311509573706/?business_id=898179107217559,Central Iowa Times,,
+3.224.13.68,centralmissourinews.com,,,,
+3.224.13.68,centralndnews.com,,,,
+3.224.13.68,centralsdnews.com,,,,
+3.224.13.68,centralstlnews.com,,,,
+3.224.13.68,clayreporter.com,,,,
+3.224.13.68,columbiamonews.com,,,,
+3.224.13.68,cornhuskerstatenews.com,,,,
+3.224.13.68,dakotatimes.com,https://business.facebook.com/Dakota-Times-101460081279893/?business_id=898179107217559,Dakota Times,,
+3.224.13.68,desmoinessun.com,https://business.facebook.com/Des-Moines-Sun-101958604552546/?business_id=898179107217559,Des Moines Sun,,
+3.224.13.68,dubuquetimes.com,https://business.facebook.com/Dubuque-Times-114048820002219/?business_id=898179107217559,Dubuque Times,,
+3.224.13.68,eastokcnews.com,,,,
+3.224.13.68,easttwincities.com,https://business.facebook.com/East-Twin-Cities-102017971223826/?business_id=898179107217559,East Twin Cities,,
+3.224.13.68,eastwichitatimes.com,,,,
+3.224.13.68,eciowanews.com,https://business.facebook.com/East-Central-Iowa-News-102928174455039/?business_id=898179107217559,East Central Iowa News,,
+3.224.13.68,eckansasnews.com,,,,
+3.224.13.68,ecnebraskanews.com,,,,
+3.224.13.68,ecoklahomanews.com,,,,
+3.224.13.68,fargostandard.com,,,,
+3.224.13.68,hawkeyereporter.com,https://www.facebook.com/Hawkeye-Reporter-110638887011923/,Hawkeye Reporter,,
+3.224.13.68,hutchtoday.com,,,,
+3.224.13.68,iowacitytoday.com,https://www.facebook.com/Iowa-City-Today-116453419760333/,Iowa City Today,,
+3.224.13.68,jeffcitynews.com,,,,
+3.224.13.68,jeffcotimes.com,,,,
+3.224.13.68,jocotoday.com,,,,
+3.224.13.68,kcreporter.com,,,,
+3.224.13.68,lawrencereporter.com,,,,
+3.224.13.68,minneapolisreview.com,https://business.facebook.com/Minneapolis-Review-102334997858514/?business_id=898179107217559,Minneapolis Review,,
+3.224.13.68,minnesotastatewire.com,,Minnesota State Wire,,
+3.224.13.68,nckansasnews.com,,,,
+3.224.13.68,ncminnesotanews.com,https://business.facebook.com/NC-Minnesota-News-100963467997125/?business_id=898179107217559,NC Minnesota News,,
+3.224.13.68,ncoklahomanews.com,,,,
+3.224.13.68,ndnorthnews.com,,,,
+3.224.13.68,neiowanews.com,https://www.facebook.com/NE-Iowa-News-115073833239021/,NE Iowa News,,
+3.224.13.68,nekansascitynews.com,,,,
+3.224.13.68,nekansasnews.com,,,,
+3.224.13.68,nemissourinews.com,,,,
+3.224.13.68,nenebraskanews.com,,,,
+3.224.13.68,nenorthdakotanews.com,,,,
+3.224.13.68,neoklahomanews.com,,,,
+3.224.13.68,nepanhandlenews.com,,,,
+3.224.13.68,nesdnews.com,,,,
+3.224.13.68,northdsmnews.com,https://www.facebook.com/North-DSM-News-102122281204867/,North DSM News,,
+3.224.13.68,northhennepinnews.com,https://business.facebook.com/North-Hennepin-News-111056933643780/?business_id=898179107217559,North Hennepin News,,
+3.224.13.68,northiowareporter.com,https://www.facebook.com/North-Iowa-Reporter-109005527181560/,North Iowa Reporter,,
+3.224.13.68,northokcnews.com,,,,
+3.224.13.68,northomahatimes.com,,,,
+3.224.13.68,northramseynews.com,https://business.facebook.com/North-Ramsey-News-102264164531959/?business_id=898179107217559,North Ramsey News,,
+3.224.13.68,northstlnews.com,,,,
+3.224.13.68,northtulsatoday.com,,,,
+3.224.13.68,northwichitanews.com,,,,
+3.224.13.68,nwiowanews.com,https://www.facebook.com/NW-Iowa-News-111152886960129/,NW Iowa News,,
+3.224.13.68,nwkansasnews.com,,,,
+3.224.13.68,nwminnesotanews.com,https://business.facebook.com/NW-Minnesota-News-104290047660202/?business_id=898179107217559,NW Minnesota News,,
+3.224.13.68,nwmissouritimes.com,,,,
+3.224.13.68,nwoklahomanews.com,,,,
+3.224.13.68,nwtwincities.com,https://business.facebook.com/NW-Twin-Cities-102320397859854/?business_id=898179107217559,NW Twin Cities,,
+3.224.13.68,okcstandard.com,,,,
+3.224.13.68,omaharecord.com,,,,
+3.224.13.68,peacegardennews.com,,,,
+3.224.13.68,plattenews.com,,,,
+3.224.13.68,riverbendtimes.com,https://www.facebook.com/River-Bend-Times-101474471267975/,River Bend Times,,
+3.224.13.68,rushmorestatenews.com,,,,
+3.224.13.68,sandhillstoday.com,,,,
+3.224.13.68,sckansasnews.com,,,,
+3.224.13.68,scminnesotanews.com,https://business.facebook.com/SC-Minnesota-News-113239810090802/?business_id=898179107217559,SC Minnesota News,,
+3.224.13.68,scmissourinews.com,,,,
+3.224.13.68,scnebraskanews.com,,,,
+3.224.13.68,scoklahomanews.com,,,,
+3.224.13.68,seiowanews.com,https://www.facebook.com/SE-Iowa-News-120767729327293/,SE Iowa News,,
+3.224.13.68,sekansascitynews.com,,,,
+3.224.13.68,sekansasnews.com,,,,
+3.224.13.68,seminnesotanews.com,https://business.facebook.com/SE-Minnesota-News-100587221369269/?business_id=898179107217559,SE Minnesota News,,
+3.224.13.68,semissourinews.com,,,,
+3.224.13.68,senebraskanews.com,,,,
+3.224.13.68,seoklahomanews.com,,,,
+3.224.13.68,sesdnews.com,,,,
+3.224.13.68,setwincities.com,https://business.facebook.com/SE-Twin-Cities-114885659925192/?business_id=898179107217559,SE Twin Cities,,
+3.224.13.68,showmestatetimes.com,,,,
+3.224.13.68,siouxcitytimes.com,https://www.facebook.com/Sioux-City-Times-102939701120339/,Sioux City Times,,
+3.224.13.68,siouxempiretoday.com,,,,
+3.224.13.68,soonerstatenews.com,,,,
+3.224.13.68,southdsmnews.com,https://www.facebook.com/South-DSM-News-107287824015641/,South DSM News,,
+3.224.13.68,southhennepinnews.com,https://business.facebook.com/South-Hennepin-News-102092271216305/?business_id=898179107217559,South Hennepin News,,
+3.224.13.68,southiowanews.com,https://www.facebook.com/South-Iowa-News-123170839086254/,South Iowa News,,
+3.224.13.68,southkcnews.com,,,,
+3.224.13.68,southokcnews.com,,,,
+3.224.13.68,southomahatimes.com,,,,
+3.224.13.68,southstlnews.com,,,,
+3.224.13.68,southtulsatoday.com,,,,
+3.224.13.68,southwichitanews.com,,,,
+3.224.13.68,springfieldstandard.com,,,,
+3.224.13.68,stcharlestimes.com,,,,
+3.224.13.68,stcloudsun.com,https://business.facebook.com/St-Cloud-Sun-110259113723778/?business_id=898179107217559,St. Cloud Sun,,
+3.224.13.68,stlouisreporter.com,,,,
+3.224.13.68,stlwestnews.com,,,,
+3.224.13.68,stpaulreporter.com,https://business.facebook.com/St-Paul-Reporter-110279643722234/?business_id=898179107217559,St. Paul Reporter,,
+3.224.13.68,sunflowerstatenews.com,,,,
+3.224.13.68,swiowatimes.com,https://www.facebook.com/SW-Iowa-Times-124062808996714/,SW Iowa Times,,
+3.224.13.68,swkansasnews.com,,,,
+3.224.13.68,swminnesotatoday.com,https://business.facebook.com/SW-Minnesota-Today-103649764391775/?business_id=898179107217559,SW Minnesota Today,,
+3.224.13.68,swmissourinews.com,,,,
+3.224.13.68,swoklahomanews.com,,,,
+3.224.13.68,topekasun.com,,,,
+3.224.13.68,tulsastandard.com,,,,
+3.224.13.68,waterlootimes.com,https://www.facebook.com/Waterloo-Times-112715190136235/,Waterloo Times,,
+3.224.13.68,wciowanews.com,https://www.facebook.com/WC-Iowa-News-107454624005217/,WC Iowa News,,
+3.224.13.68,wcminnesotanews.com,https://business.facebook.com/WC-Minnesota-News-102223587869263/?business_id=898179107217559,WC Minnesota News,,
+3.224.13.68,wcmissourinews.com,,,,
+3.224.13.68,westdsmnews.com,https://www.facebook.com/West-DSM-News-105518977533894/,West DSM News,,
+3.224.13.68,westernndnews.com,,,,
+3.224.13.68,westernsdnews.com,,,,
+3.224.13.68,weststlnews.com,,,,
+3.224.13.68,westtwincities.com,https://business.facebook.com/West-Twin-Cities-101347867958302/?business_id=898179107217559,West Twin Cities,,
+3.224.13.68,wichitastandard.com,,,,
+3.224.13.68,wyandottetimes.com,,,,
+35.170.88.147,carbondalereporter.com,https://www.facebook.com/Carbondale-Reporter-464661937077937/,Carbondale Reporter,https://twitter.com/carbondale_news,
+35.170.88.147,chambanasun.com,https://www.facebook.com/Chambana-Sun-399174026949103,Chambana Sun,https://twitter.com/ChambanaSun,
+35.170.88.147,chicagocitywire.com,https://www.facebook.com/Chicago-City-Wire-145288335882139,Chicago City Wire,https://twitter.com/chicago_wire,
+35.170.88.147,dekalbtimes.com,https://www.facebook.com/DeKalb-Times-1650142418618920,DeKalb Times,https://twitter.com/DeKalb_Times,
+35.170.88.147,dupagepolicyjournal.com,https://www.facebook.com/DuPage-Policy-Journal-440850842779072,Dupage Policy Journal,https://twitter.com/DupageJournal,
+35.170.88.147,eastcentralreporter.com,https://www.facebook.com/East-Central-Reporter-1017551808288816,East Central Reporter,https://twitter.com/eastcentreport,
+35.170.88.147,galesburgreporter.com,https://www.facebook.com/GalesburgReporter/,Galesburg Reporter,,
+35.170.88.147,grundyreporter.com,https://www.facebook.com/Grundy-Reporter-111376299540998,Grundy Reporter,,
+35.170.88.147,illinoisvalleytimes.com,https://www.facebook.com/Illinois-Valley-Times-1544775089163392/,Illinois Valley Times,https://twitter.com/IL_valley_times,
+35.170.88.147,kanecountyreporter.com,https://www.facebook.com/Kane-County-Reporter-113001215788482/,Kane County Reporter,https://twitter.com/kane_reporter,
+35.170.88.147,kankakeetimes.com,https://www.facebook.com/kankakeetimes,Kankakee Times,https://twitter.com/Kankakee_Times,
+35.170.88.147,kendallcountytimes.com,https://www.facebook.com/Kendall-County-Times-151364972111507,Kendall County Times,,
+35.170.88.147,lakecountygazette.com,https://www.facebook.com/Lake-County-Gazette-854479238006224,Lake County Gazette,https://twitter.com/lakecntygazette,
+35.170.88.147,maconreporter.com,https://www.facebook.com/Macon-Reporter-915144198623038/,Macon Reporter,https://twitter.com/MaconReporter,
+35.170.88.147,mchenrytimes.com,https://www.facebook.com/McHenry-Times-1007855922605367,McHenry Times,https://twitter.com/McHenryTimes1,
+35.170.88.147,mcleancountytimes.com,https://www.facebook.com/McLean-County-Times-135405700298293,McLean County Times,https://twitter.com/McLean_Times,
+35.170.88.147,metroeastsun.com,https://www.facebook.com/metroeastsun,Metro East Sun,https://www.twitter.com/metroeastsun,
+35.170.88.147,northcooknews.com,https://www.facebook.com/North-Cook-News-1509066772752076,North Cook News,https://twitter.com/northcooknews,
+35.170.88.147,northegyptnews.com,https://www.facebook.com/North-Egypt-News-2042181879445200/,North Egypt News,,
+35.170.88.147,nwillinoisnews.com,https://www.facebook.com/NW-Illinois-News-386241278410290,NW Illinois News,https://twitter.com/NW_IllinoisNews,
+35.170.88.147,peoriastandard.com,https://www.facebook.com/Peoria-Standard-469649066574953/,Peoria Standard,https://twitter.com/peoria_standard,
+35.170.88.147,prairiestatewire.com,https://www.facebook.com/Prairie-State-Wire-1121259961337606,Prairie State Wire,https://twitter.com/Prairie_Wire,
+35.170.88.147,quincyreporter.com,https://www.facebook.com/Quincy-Reporter-474680926275770/,Quincy Reporter,,
+35.170.88.147,rockfordsun.com,https://www.facebook.com/Rockford-Sun-232943860486838,Rockford Sun,https://twitter.com/Rockford_Sun,
+35.170.88.147,rockislandtoday.com,https://www.facebook.com/Rock-Island-Today-969031589833777,Rock Island Today,https://twitter.com/rockislandtoday,
+35.170.88.147,sangamonsun.com,https://www.facebook.com/sangamonsun,Sangamon Sun,https://twitter.com/SangamonSun,
+35.170.88.147,seillinoisnews.com,https://www.facebook.com/Southeast-Illinois-News-1706595809591228/,SE Illinois News,https://twitter.com/seillinoisnews,
+35.170.88.147,silnews.com,https://www.facebook.com/pg/SouthernILNews,Southern Illinois News,,
+35.170.88.147,southcentralreporter.com,https://www.facebook.com/South-Central-Reporter-500024923776682/,South Central Reporter,,
+35.170.88.147,southcooknews.com,https://www.facebook.com/South-Cook-News-231679387276536,South Cook News,https://twitter.com/SouthCookNews,
+35.170.88.147,swillinoisnews.com,https://www.facebook.com/Southwest-Illinois-News-976392835784894,South West Illinois News,https://twitter.com/swillinoisnews,
+35.170.88.147,westcentralreporter.com,https://www.facebook.com/West-Central-Reporter-605712169581530,West Central Reporter,https://twitter.com/WestCentReport,
+35.170.88.147,westcooknews.com,https://www.facebook.com/West-Cook-News-337385456906651,West Cook News,https://twitter.com/westcooknews,
+35.170.88.147,willcountygazette.com,https://www.facebook.com/Will-County-Gazette-1595575670754558/,Will County Gazette,https://twitter.com/WillCoGazette,
+52.7.148.177,louisianarecord.com,https://www.facebook.com/LouisianaRecord/,Louisiana Record,https://twitter.com/louisianarecord,https://itunes.apple.com/us/app/louisiana-record/id619088844
+52.7.148.177,setexasrecord.com,https://www.facebook.com/SETexasRecord/,Southeast Texas Record,https://twitter.com/setexasrecord,https://itunes.apple.com/us/app/se-texas-record/id592747678
+52.7.148.177,socalrecord.com,,Southern California Record,,
+52.7.148.177,pennrecord.com,https://www.facebook.com/pages/Pennsylvania-Record/338776239487764,Pennsylvania Record,https://twitter.com/pennrecord,https://itunes.apple.com/us/app/pennsylvania-record/id623294648
+52.7.148.177,norcalrecord.com,https://www.facebook.com/Northern-California-Record-975849335817140/,Northern California Record,https://twitter.com/norcal_record,https://itunes.apple.com/us/app/northern-california/id1250360608?mt=8
+52.7.148.177,wvrecord.com,https://www.facebook.com/WVRecord,West Virginia Record,https://twitter.com/wvrecord,https://itunes.apple.com/us/app/wv-record/id599538288
+52.7.148.177,stlrecord.com,https://www.facebook.com/stlrecord,St. Louis Record,https://twitter.com/St_Louis_Record,https://itunes.apple.com/us/app/st-louisrecord/id1260557950
+52.7.148.177,legalnewsline.com,https://www.facebook.com/pages/Legal-Newsline/299588323424419,Legal Newsline,http://twitter.com/legalnewsline,https://itunes.apple.com/us/app/legal-newsline/id603098697?mt=8
+52.7.148.177,cookcountyrecord.com,https://www.facebook.com/cookcountyrecord,Cook County Record,https://twitter.com/CookRecord,https://itunes.apple.com/us/app/cook-county-record/id715265623?mt=8
+52.7.148.177,flarecord.com,https://www.facebook.com/Florida-Record-772624976214511/,Florida Record,https://twitter.com/FloridaRecord,https://itunes.apple.com/us/app/florida-record/id1247782056?mt=8
+52.7.148.177,madisonrecord.com,https://www.facebook.com/pages/MadisonSt-Clair-Record/164779816968453,Madison - St. Clair Record,https://twitter.com/madisonrecord,https://itunes.apple.com/us/app/madison-st-clair-record/id597238468?mt=8


### PR DESCRIPTION
Based on the new urls found by @Bermos in #8, I've re-crawled the sites and added `twitterUrl`s and `itunesAppStoreUrl`s. Looks like sites on a particular IP all share mostly the same page "features" (only the new ones have twitter/app store urls).